### PR TITLE
[FEAT] 메뉴 추가화면 초기 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.espresso.core)
+    implementation(libs.play.services.location)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:name=".OurMenuApp"

--- a/app/src/main/java/com/kuit/ourmenu/ui/addmenu/component/bottomsheet/AddMenuBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/addmenu/component/bottomsheet/AddMenuBottomSheetContent.kt
@@ -35,9 +35,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.LocalPlatformContext
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
 import com.kuit.ourmenu.R
+import com.kuit.ourmenu.data.model.map.response.CrawlingStoreDetailResponse
 import com.kuit.ourmenu.ui.addmenu.component.item.SelectMenuItem
-import com.kuit.ourmenu.ui.addmenu.viewmodel.AddMenuDummyStoreInfo
 import com.kuit.ourmenu.ui.addmenu.viewmodel.AddMenuViewModel
 import com.kuit.ourmenu.ui.common.BottomFullWidthButton
 import com.kuit.ourmenu.ui.theme.Neutral100
@@ -54,11 +57,13 @@ import kotlinx.coroutines.launch
 @Composable
 fun AddMenuBottomSheetContent(
     scaffoldState: BottomSheetScaffoldState,
-    storeInfo: AddMenuDummyStoreInfo,
+    storeInfo: CrawlingStoreDetailResponse,
+    selectedMenuIndex: Int?,
+    onNavigateToAddMenuInfo: () -> Unit,
     onItemClick: (Int) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val enableNextButton = storeInfo.menuList.any { it }
+    val enableNextButton = selectedMenuIndex != null
 
     Column(
         modifier = Modifier
@@ -66,7 +71,7 @@ fun AddMenuBottomSheetContent(
             .padding(start = 20.dp, end = 20.dp, bottom = 20.dp)
     ) {
         Text(
-            text = "식당 이름",
+            text = storeInfo.storeTitle,
             style = ourMenuTypography().pretendard_700_20
         )
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
@@ -77,7 +82,7 @@ fun AddMenuBottomSheetContent(
                 tint = Color.Unspecified
             )
             Text(
-                text = "주소에 해당하는 텍스트",
+                text = storeInfo.storeAddress,
                 style = ourMenuTypography().pretendard_500_14,
                 color = Neutral700,
                 modifier = Modifier.padding(start = 8.dp)
@@ -89,34 +94,28 @@ fun AddMenuBottomSheetContent(
                 .fillMaxWidth()
                 .padding(top = 8.dp), horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            //이미지 3개 배치
-            Image(
-                painter = painterResource(id = R.drawable.img_dummy_pizza),
-                contentDescription = "dummy data",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .width(104.dp)
-                    .height(80.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
-            Image(
-                painter = painterResource(id = R.drawable.img_dummy_pizza),
-                contentDescription = "dummy data",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .width(104.dp)
-                    .height(80.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
-            Image(
-                painter = painterResource(id = R.drawable.img_dummy_pizza),
-                contentDescription = "dummy data",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .width(104.dp)
-                    .height(80.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
+            // 이미지 3개 배치
+            for(i in 0..2) {
+                Image(
+                    painter = if (i < storeInfo.storeImgs.size) {
+                        rememberAsyncImagePainter(
+                            model = ImageRequest.Builder(LocalPlatformContext.current)
+                                // 전달 받는 storeImgs의 값에 https://가 없이 전달됨
+                                .data("https://"+storeInfo.storeImgs[i])
+                                .size(104, 80)
+                                .build()
+                        )
+                    } else {
+                        painterResource(id = R.drawable.img_dummy_menu)
+                    },
+                    contentDescription = "img${i + 1}",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .width(104.dp)
+                        .height(80.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                )
+            }
         }
         //BottomSheet가 확장된 상태가 아닐 때 (AddMenuScreen에서) 보여줄 버튼
         if (scaffoldState.bottomSheetState.targetValue != SheetValue.Expanded) {
@@ -143,10 +142,10 @@ fun AddMenuBottomSheetContent(
                     .weight(1f)
                     .padding(top = 12.dp)
             ) {
-                itemsIndexed(storeInfo.menuList) { index, isSelected ->
-//                    Log.d("AddMenuBottomSheetContent", "Item: $index, $isSelected")
+                itemsIndexed(storeInfo.menus) { index, menu ->
                     SelectMenuItem(
-                        isSelected = isSelected,
+                        menu = menu,
+                        isSelected = selectedMenuIndex == index,
                         onClick = { onItemClick(index) }
                     )
                 }
@@ -168,9 +167,9 @@ fun AddMenuBottomSheetContent(
                 ) {
                     if (enableNextButton){
                         //버튼 활성화 된 경우의 동작
+                        onNavigateToAddMenuInfo()
                     }
                 }
-
             }
         }
     }
@@ -183,11 +182,25 @@ private fun AddMenuBottomSheetContentPreview() {
     val scaffoldState = rememberBottomSheetScaffoldState()
     val viewModel: AddMenuViewModel = viewModel()
     val storeInfo by viewModel.storeInfo.collectAsStateWithLifecycle()
+    val selectedMenuIndex by viewModel.selectedMenuIndex.collectAsStateWithLifecycle()
+    
     LaunchedEffect(Unit) {
         //아래 주석 해제하면 bottom sheet 확장된 상태 확인 가능
         scaffoldState.bottomSheetState.expand()
     }
-    AddMenuBottomSheetContent(scaffoldState, storeInfo) { index ->
-        viewModel.updateSelectedMenu(index = index)
-    }
+    AddMenuBottomSheetContent(
+        scaffoldState = scaffoldState,
+        storeInfo = storeInfo ?: CrawlingStoreDetailResponse(
+            storeId = "",
+            storeTitle = "",
+            storeAddress = "",
+            storeImgs = emptyList(),
+            menus = emptyList(),
+            storeMapX = 0.0,
+            storeMapY = 0.0
+        ),
+        selectedMenuIndex = selectedMenuIndex,
+        onNavigateToAddMenuInfo = {},
+        onItemClick = { index -> viewModel.updateSelectedMenu(index) }
+    )
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/addmenu/component/item/SelectMenuItem.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/addmenu/component/item/SelectMenuItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kuit.ourmenu.R
+import com.kuit.ourmenu.data.model.map.response.CrawlingMenuDetail
 import com.kuit.ourmenu.ui.theme.Neutral300
 import com.kuit.ourmenu.ui.theme.Neutral700
 import com.kuit.ourmenu.ui.theme.NeutralWhite
@@ -29,7 +30,11 @@ import com.kuit.ourmenu.ui.theme.Primary500Main
 import com.kuit.ourmenu.ui.theme.ourMenuTypography
 
 @Composable
-fun SelectMenuItem(isSelected: Boolean = false, onClick: () -> Unit) {
+fun SelectMenuItem(
+    menu: CrawlingMenuDetail,
+    isSelected: Boolean = false,
+    onClick: () -> Unit
+) {
     HorizontalDivider(
         thickness = 1.dp,
         color = Neutral300,
@@ -44,11 +49,11 @@ fun SelectMenuItem(isSelected: Boolean = false, onClick: () -> Unit) {
     ) {
         Column {
             Text(
-                text = "메뉴 이름",
+                text = menu.menuTitle,
                 style = ourMenuTypography().pretendard_700_16
             )
             Text(
-                text = "14,000원",
+                text = menu.menuPrice,
                 style = ourMenuTypography().pretendard_500_14,
                 color = Neutral700,
             )
@@ -93,7 +98,21 @@ fun SelectMenuItem(isSelected: Boolean = false, onClick: () -> Unit) {
 @Composable
 private fun SelectedMenuItemPreview() {
     Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.Center) {
-        SelectMenuItem(false, onClick = {})
-        SelectMenuItem(true, onClick = {})
+        SelectMenuItem(
+            menu = CrawlingMenuDetail(
+                menuTitle = "떡볶이",
+                menuPrice = "14,000원"
+            ),
+            isSelected = false,
+            onClick = {}
+        )
+        SelectMenuItem(
+            menu = CrawlingMenuDetail(
+                menuTitle = "치킨",
+                menuPrice = "18,000원"
+            ),
+            isSelected = true,
+            onClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/addmenu/navigation/AddMenuNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/addmenu/navigation/AddMenuNavigation.kt
@@ -1,0 +1,28 @@
+package com.kuit.ourmenu.ui.addmenu.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.kuit.ourmenu.ui.addmenu.screen.AddMenuInfoScreen
+import com.kuit.ourmenu.ui.addmenu.screen.AddMenuScreen
+import com.kuit.ourmenu.ui.navigator.Routes
+
+
+fun NavController.navigateToAddMenuInfo() {
+    navigate(Routes.AddMenuInfo)
+}
+
+fun NavGraphBuilder.addMenuNavGraph(
+    navigateBack: () -> Unit,
+    navigateToAddMenuInfo: () -> Unit
+) {
+    composable<Routes.AddMenu> {
+        AddMenuScreen(
+            onNavigateToAddMenuInfo = navigateToAddMenuInfo
+        )
+    }
+
+    composable<Routes.AddMenuInfo> {
+        AddMenuInfoScreen()
+    }
+}

--- a/app/src/main/java/com/kuit/ourmenu/ui/addmenu/screen/AddMenuScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/addmenu/screen/AddMenuScreen.kt
@@ -80,25 +80,30 @@ fun AddMenuScreen(
     // Collect history data from ViewModel
     val searchHistory by viewModel.searchHistory.collectAsState()
 
-    // Handle location permission
-    PermissionHandler(
-        permission = Manifest.permission.ACCESS_FINE_LOCATION,
-        rationaleMessage = "Location permission is required to show your current location on the map",
-        onPermissionGranted = {
-            viewModel.updateLocationPermission(true)
-        },
-        onPermissionDenied = {
-            viewModel.updateLocationPermission(false)
-        }
-    )
+    // 권한 허용이 안된 경우 권한 요청
+    if (!locationPermissionGranted) {
+        PermissionHandler(
+            permission = Manifest.permission.ACCESS_FINE_LOCATION,
+            rationaleMessage = "Location permission is required to show your current location on the map",
+            onPermissionGranted = {
+                viewModel.updateLocationPermission(true)
+            },
+            onPermissionDenied = {
+                viewModel.updateLocationPermission(false)
+            }
+        )
+    }
 
     val mapView = mapViewWithLifecycle(
         mapController = viewModel.mapController
     ) { kakaoMap ->
-        // Map will be initialized in LaunchedEffect when permission is granted
+        // 이미 permission 허용한 경우
+        if (locationPermissionGranted) {
+            viewModel.initializeMap(kakaoMap, context)
+        }
     }
 
-    // Initialize map when permission is granted
+    // permission 여부 변한 경우에 발생
     LaunchedEffect(locationPermissionGranted) {
         if (locationPermissionGranted) {
             viewModel.mapController.kakaoMap.value?.let { kakaoMap ->

--- a/app/src/main/java/com/kuit/ourmenu/ui/addmenu/viewmodel/AddMenuViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/addmenu/viewmodel/AddMenuViewModel.kt
@@ -57,6 +57,7 @@ class AddMenuViewModel @Inject constructor(
         viewModelScope.launch {
             preferencesManager.locationPermissionGranted.collect { granted ->
                 _locationPermissionGranted.value = granted
+                Log.d("AddMenuViewModel", "location permission : $granted")
             }
         }
     }
@@ -78,11 +79,11 @@ class AddMenuViewModel @Inject constructor(
             location?.let {
                 Log.d("AddMenuViewModel", "location success: lat=${it.latitude}, long=${it.longitude}")
                 moveCamera(it.latitude, it.longitude)
-                addMarker(it.latitude, it.longitude, R.drawable.img_popup_dice)
+//                addMarker(it.latitude, it.longitude, R.drawable.img_popup_dice)
             } ?: run {
                 Log.d("AddMenuViewModel", "location fail")
                 moveCamera(37.5416, 127.0793)
-                addMarker(37.5416, 127.0793, R.drawable.img_popup_dice)
+//                addMarker(37.5416, 127.0793, R.drawable.img_popup_dice)
             }
         }
     }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
@@ -24,11 +24,16 @@ fun NavController.navigateToMenuFolderAllMenu() {
     navigate(Routes.MenuFolderAllMenu)
 }
 
+fun NavController.navigateToAddMenu() {
+    navigate(Routes.AddMenu)
+}
+
 fun NavGraphBuilder.menuFolderNavGraph(
     navigateBack: () -> Unit,
     navigateToMenuFolderDetail: (Int) -> Unit,
     navigateToMenuFolderAllMenu: () -> Unit,
 //    navigateToMenuInfo: () -> Unit,
+    navigateToAddMenu: () -> Unit
 ) {
     composable<MainTabRoute.MenuFolder> {
         MenuFolderScreen(
@@ -43,6 +48,7 @@ fun NavGraphBuilder.menuFolderNavGraph(
                 menuFolderId = menuFolderId,
 //                onNavigateToMenuInfo = navigateToMenuInfo,
                 onNavigateBack = navigateBack,
+                onNavigateToAddMenu = navigateToAddMenu
             )
         }
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
@@ -28,17 +28,12 @@ fun NavController.navigateToAddMenu() {
     navigate(Routes.AddMenu)
 }
 
-fun NavController.navigateToAddMenuInfo() {
-    navigate(Routes.AddMenuInfo)
-}
-
 fun NavGraphBuilder.menuFolderNavGraph(
     navigateBack: () -> Unit,
     navigateToMenuFolderDetail: (Int) -> Unit,
     navigateToMenuFolderAllMenu: () -> Unit,
 //    navigateToMenuInfo: () -> Unit,
     navigateToAddMenu: () -> Unit,
-    navigateToAddMenuInfo: () -> Unit
 ) {
     composable<MainTabRoute.MenuFolder> {
         MenuFolderScreen(

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
@@ -28,12 +28,17 @@ fun NavController.navigateToAddMenu() {
     navigate(Routes.AddMenu)
 }
 
+fun NavController.navigateToAddMenuInfo() {
+    navigate(Routes.AddMenuInfo)
+}
+
 fun NavGraphBuilder.menuFolderNavGraph(
     navigateBack: () -> Unit,
     navigateToMenuFolderDetail: (Int) -> Unit,
     navigateToMenuFolderAllMenu: () -> Unit,
 //    navigateToMenuInfo: () -> Unit,
-    navigateToAddMenu: () -> Unit
+    navigateToAddMenu: () -> Unit,
+    navigateToAddMenuInfo: () -> Unit
 ) {
     composable<MainTabRoute.MenuFolder> {
         MenuFolderScreen(

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderDetailScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderDetailScreen.kt
@@ -49,7 +49,7 @@ fun MenuFolderDetailScreen(
     menuFolderId: Int,
 //    onNavigateToMenuInfo: () -> Unit, // TODO: Menu Info로 화면 이동 구현
 //    onNavigateToMap: () -> Unit, // TODO: Map으로 화면 이동 구현
-//    onNavigateToAddMenu: () -> Unit, // TODO: AddMenu로 화면 이동 구현
+    onNavigateToAddMenu: () -> Unit, // TODO: AddMenu로 화면 이동 구현
     onNavigateBack: () -> Unit,
     viewModel: MenuFolderDetailViewModel = hiltViewModel()
 ) {
@@ -159,7 +159,7 @@ fun MenuFolderDetailScreen(
                             stringResource(R.string.add_menu),
                             modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 20.dp)
                         ) {
-//                            onNavigateToAddMenu()
+                            onNavigateToAddMenu()
                         }
                     }
                 }
@@ -180,7 +180,7 @@ private fun MenuFolderDetailScreenPreview() {
         menuFolderId = 0,
 //        onNavigateToMenuInfo = {},
 //        onNavigateToMap = {},
-//        onNavigateToAddMenu = {},
+        onNavigateToAddMenu = {},
         onNavigateBack = {},
     )
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
@@ -7,9 +7,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.kuit.ourmenu.ui.addmenu.navigation.navigateToAddMenuInfo
 import com.kuit.ourmenu.ui.home.navigation.navigateToHome
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToAddMenu
-import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToAddMenuInfo
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolder
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolderAllMenu
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolderDetail

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.kuit.ourmenu.ui.home.navigation.navigateToHome
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToAddMenu
+import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToAddMenuInfo
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolder
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolderAllMenu
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolderDetail
@@ -97,6 +98,10 @@ class MainNavController(
 
     fun navigateToAddMenu() {
         navController.navigateToAddMenu()
+    }
+
+    fun navigateToAddMenuInfo() {
+        navController.navigateToAddMenuInfo()
     }
 
     @Composable

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.kuit.ourmenu.ui.home.navigation.navigateToHome
+import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToAddMenu
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolder
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolderAllMenu
 import com.kuit.ourmenu.ui.menuFolder.navigation.navigateToMenuFolderDetail
@@ -92,6 +93,10 @@ class MainNavController(
 
     fun navigateToMenuFolderAllMenu() {
         navController.navigateToMenuFolderAllMenu()
+    }
+
+    fun navigateToAddMenu() {
+        navController.navigateToAddMenu()
     }
 
     @Composable

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
@@ -60,7 +60,8 @@ fun MainNavHost(
             navigateToMenuFolderDetail = navController::navigateToMenuFolderDetail,
             navigateToMenuFolderAllMenu = navController::navigateToMenuFolderAllMenu,
 //            navigateToMenuInfo = navController::navigateToMenuInfo,
-            navigateToAddMenu = navController::navigateToAddMenu
+            navigateToAddMenu = navController::navigateToAddMenu,
+            navigateToAddMenuInfo = navController::navigateToAddMenuInfo
         )
 
         searchMenuNavGraph(
@@ -98,7 +99,9 @@ fun MainNavHost(
 
         // 메뉴 추가
         composable<Routes.AddMenu> {
-            AddMenuScreen()
+            AddMenuScreen(
+                onNavigateToAddMenuInfo = navController::navigateToAddMenuInfo
+            )
         }
     }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
@@ -7,6 +7,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.kuit.ourmenu.ui.addmenu.navigation.addMenuNavGraph
 import com.kuit.ourmenu.ui.addmenu.screen.AddMenuScreen
 import com.kuit.ourmenu.ui.home.navigation.homeNavGraph
 import com.kuit.ourmenu.ui.menuFolder.navigation.menuFolderNavGraph
@@ -61,6 +62,10 @@ fun MainNavHost(
             navigateToMenuFolderAllMenu = navController::navigateToMenuFolderAllMenu,
 //            navigateToMenuInfo = navController::navigateToMenuInfo,
             navigateToAddMenu = navController::navigateToAddMenu,
+        )
+
+        addMenuNavGraph(
+            navigateBack = navController::navigateUp,
             navigateToAddMenuInfo = navController::navigateToAddMenuInfo
         )
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
@@ -60,6 +60,7 @@ fun MainNavHost(
             navigateToMenuFolderDetail = navController::navigateToMenuFolderDetail,
             navigateToMenuFolderAllMenu = navController::navigateToMenuFolderAllMenu,
 //            navigateToMenuInfo = navController::navigateToMenuInfo,
+            navigateToAddMenu = navController::navigateToAddMenu
         )
 
         searchMenuNavGraph(
@@ -77,9 +78,7 @@ fun MainNavHost(
                 menuFolderId = menuFolderId,
                 onNavigateBack = navController::navigateUp,
 //                onNavigateToMenuInfo = navController::navigateToMenuInfo,
-//                onNavigateToAddMenu = { menuId ->
-//                    navController.navigateToAddMenu(menuId)
-//                }
+                onNavigateToAddMenu = navController::navigateToAddMenu
             )
         }
         composable<Routes.MenuFolderAllMenu> {

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/Routes.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/Routes.kt
@@ -21,6 +21,8 @@ sealed interface Routes{
     // 메뉴 추가
     @Serializable
     data object AddMenu: Routes
+    @Serializable
+    data object AddMenuInfo: Routes
 
     // Mypage
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
@@ -192,7 +192,7 @@ fun SearchMenuScreen(
                         val (latitude, longitude) = center
                         Log.d("SearchMenuScreen", "검색 위치: $latitude, $longitude")
                         
-                        // 검색어와 현재 좌표로 크롤링 스토어 정보 요청
+                        // 검색어와 현재 좌표로 스토어 정보 요청
                         viewModel.getMapSearchResult(
                             query = searchText,
                             long = longitude,

--- a/app/src/main/java/com/kuit/ourmenu/utils/PermissionHandler.kt
+++ b/app/src/main/java/com/kuit/ourmenu/utils/PermissionHandler.kt
@@ -1,0 +1,81 @@
+package com.kuit.ourmenu.utils
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+@Composable
+fun PermissionHandler(
+    permission: String,
+    rationaleMessage: String,
+    onPermissionGranted: () -> Unit,
+    onPermissionDenied: () -> Unit
+) {
+    val context = LocalContext.current
+    val showRationaleDialog = remember { mutableStateOf(false) }
+    
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            onPermissionGranted()
+        } else {
+            onPermissionDenied()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        when {
+            ContextCompat.checkSelfPermission(
+                context,
+                permission
+            ) == PackageManager.PERMISSION_GRANTED -> {
+                onPermissionGranted()
+            }
+            (context as? Activity)?.shouldShowRequestPermissionRationale(permission) == true -> {
+                showRationaleDialog.value = true
+            }
+            else -> {
+                launcher.launch(permission)
+            }
+        }
+    }
+
+    if (showRationaleDialog.value) {
+        AlertDialog(
+            onDismissRequest = { showRationaleDialog.value = false },
+            title = { Text("Permission Required") },
+            text = { Text(rationaleMessage) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showRationaleDialog.value = false
+                        launcher.launch(permission)
+                    }
+                ) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { 
+                        showRationaleDialog.value = false
+                        onPermissionDenied()
+                    }
+                ) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/kuit/ourmenu/utils/PreferencesManager.kt
+++ b/app/src/main/java/com/kuit/ourmenu/utils/PreferencesManager.kt
@@ -1,0 +1,37 @@
+package com.kuit.ourmenu.utils
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+@Singleton
+class PreferencesManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private val LOCATION_PERMISSION_GRANTED =
+            booleanPreferencesKey("location_permission_granted")
+    }
+
+    val locationPermissionGranted: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[LOCATION_PERMISSION_GRANTED] ?: false
+        }
+
+    suspend fun setLocationPermissionGranted(granted: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[LOCATION_PERMISSION_GRANTED] = granted
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ navigationCompose = "2.8.6"
 okhttp = "4.11.0"
 retrofitKotlinSerializationConverter = "1.0.0"
 datastorePreferences = "1.1.3"
+playServicesLocation = "21.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -57,6 +58,7 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor" }
 retrofit-kotlin-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinSerializationConverter" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 🚀 이슈번호

## ✏️ 변경사항
- 현재 위치를 불러오기 위한 의존성 추가
- 현재 위치 접근에 필요한 권한 요청 및 관리를 위한 PreferencesManager 작성
- 메뉴 추가에서의 검색 기능 구현


## 📷 스크린샷
권한 요청
<img width="489" alt="image" src="https://github.com/user-attachments/assets/9e580df8-8f1c-4f5b-952b-70fbc01f778e" />

검색 후 메뉴 선택시 화면
<img width="489" alt="image" src="https://github.com/user-attachments/assets/43620773-b86a-4de8-ab3c-6ecad2e012a4" />

## ✍️ 사용법
메뉴를 추가하는 과정에서 필요한 기본적인 화면 연결을 구현하였습니다. 다른 작업에 선행되어야 하는 부분이라 우선은 기본적인 연결만 된 상태로 pr을 올렸고 세부적인 수정 사항들은 이후에 작업하여 추가적으로 올리도록 하겠습니다

## 🎸 기타
