### PR TITLE
[FEAT] 지도 메뉴에서의 등록된 메뉴 조회 기능 구현

### DIFF
--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapDetailResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapDetailResponse.kt
@@ -11,10 +11,10 @@ data class MapDetailResponse(
     val menuTitle: String,
     @SerialName("menuPrice")
     val menuPrice: Int,
-    @SerialName("menuPin")
-    val menuPin: String,
-    @SerialName("menuTags")
-    val menuTags: List<String>,
+    @SerialName("menuPinImgUrl")
+    val menuPinImgUrl: String,
+    @SerialName("menuTagImgUrls")
+    val menuTagImgUrls: List<String>,
     @SerialName("menuImgUrls")
     val menuImgUrls: List<String>,
     @SerialName("menuFolderInfo")
@@ -31,8 +31,8 @@ data class MapDetailResponse(
 data class MenuFolderInfo(
     @SerialName("menuFolderTitle")
     val menuFolderTitle: String,
-    @SerialName("menuFolderIcon")
-    val menuFolderIcon: String,
+    @SerialName("menuFolderIconImgUrl")
+    val menuFolderIconImgUrl: String,
     @SerialName("menuFolderCount")
     val menuFolderCount: Int
 )

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapMenuDetailResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapMenuDetailResponse.kt
@@ -11,10 +11,10 @@ data class MapMenuDetailResponse(
     val menuTitle: String,
     @SerialName("menuPrice")
     val menuPrice: Int,
-    @SerialName("menuPin")
-    val menuPin: String,
-    @SerialName("menuTags")
-    val menuTags: List<String>,
+    @SerialName("menuPinImgUrl")
+    val menuPinImgUrl: String,
+    @SerialName("menuTagImgUrls")
+    val menuTagImgUrls: List<String>,
     @SerialName("menuImgUrls")
     val menuImgUrls: List<String>,
     @SerialName("menuFolderInfo")

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapResponse.kt
@@ -9,8 +9,8 @@ data class MapResponse(
     val mapId: Long,
     @SerialName("menuPinImgUrl")
     val menuPinImgUrl: String,
-    @SerialName("menuPinDisabledImgUrl")
-    val menuPinDisabledImgUrl: String,
+    @SerialName("menuPinDisableImgUrl")
+    val menuPinDisableImgUrl: String,
     @SerialName("mapX")
     val mapX: Double,
     @SerialName("mapY")

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapResponse.kt
@@ -7,8 +7,10 @@ import kotlinx.serialization.Serializable
 data class MapResponse(
     @SerialName("mapId")
     val mapId: Long,
-    @SerialName("menuPins")
-    val menuPins: List<String>,
+    @SerialName("menuPinImgUrl")
+    val menuPinImgUrl: String,
+    @SerialName("menuPinDisabledImgUrl")
+    val menuPinDisabledImgUrl: String,
     @SerialName("mapX")
     val mapX: Double,
     @SerialName("mapY")

--- a/app/src/main/java/com/kuit/ourmenu/data/service/MapService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/MapService.kt
@@ -18,15 +18,15 @@ interface MapService {
     @GET("api/users/menus/{mapId}/maps")
     suspend fun getMapDetail(
         @Path("mapId") mapId: Long
-    ): BaseResponse<List<MapDetailResponse>>
+    ): BaseResponse<List<MapDetailResponse>> // TODO: 리팩토링
 
     @GET("api/users/menus/maps")
-    suspend fun getMap(): BaseResponse<List<MapResponse>>
+    suspend fun getMap(): BaseResponse<List<MapResponse>> // TODO: 리팩토링
 
     @GET("api/users/menus/maps/{menuId}/search")
     suspend fun getMapMenuDetail(
         @Path("menuId") menuId: Long
-    ): BaseResponse<MapMenuDetailResponse>
+    ): BaseResponse<MapMenuDetailResponse> // TODO: 리팩토링
 
     @GET("api/users/menus/maps/search")
     suspend fun getMapSearch(

--- a/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,7 +29,6 @@ import com.kuit.ourmenu.R
 import com.kuit.ourmenu.data.model.map.response.MapDetailResponse
 import com.kuit.ourmenu.data.model.map.response.MenuFolderInfo
 import com.kuit.ourmenu.ui.common.chip.MenuFolderChip
-import com.kuit.ourmenu.ui.common.chip.TagChip
 import com.kuit.ourmenu.ui.theme.Neutral500
 import com.kuit.ourmenu.ui.theme.Neutral700
 import com.kuit.ourmenu.ui.theme.Neutral900
@@ -108,11 +107,12 @@ fun MenuInfoContent(
             MenuFolderChip(
                 modifier = Modifier
                     .align(Alignment.CenterEnd),
+                menuFolderIconImgUrl = menuInfoData.menuFolderInfo.menuFolderIconImgUrl,
                 menuFolderTitle = menuFolderTitle
             )
         }
         Text(
-            text = menuInfoData.menuFolderInfo.menuFolderTitle,
+            text = "응답에 가게명 누락", // TODO: 가게명 처리
             style = ourMenuTypography().pretendard_600_14.copy(
                 lineHeight = 12.sp,
                 color = Neutral500
@@ -159,17 +159,21 @@ fun MenuInfoTagContent(
 ) {
     FlowRow(modifier = modifier) {
         menuTags.forEach { tag ->
-            TagChip(
-                modifier = Modifier.padding(
-                    top = 4.dp,
-                ),
-                tagIcon = R.drawable.ic_tag_rice, // TODO: Get appropriate icon based on tag
-                tagName = tag,
-                enabled = false,
-                selected = true,
-                onClick = { }
+            val painter = rememberAsyncImagePainter(
+                model = ImageRequest.Builder(LocalPlatformContext.current)
+                    .data(tag)
+                    .size(96, 32)
+                    .build()
             )
-            Spacer(modifier = Modifier.padding(end = 4.dp))
+
+            Image(
+                painter = painter,
+                contentDescription = null,
+                modifier = Modifier
+                    .height(32.dp)
+                    .padding(top = 4.dp, end = 4.dp),
+                contentScale = ContentScale.FillHeight
+            )
         }
     }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
@@ -86,7 +86,9 @@ fun MenuInfoContent(
                     .align(Alignment.CenterStart)
             ) {
                 Text(
-                    text = menuInfoData.menuTitle,
+                    text = with(menuInfoData.menuTitle) {
+                        if (length > 10) take(10) + "..." else this
+                    },
                     style = ourMenuTypography().pretendard_700_20.copy(
                         lineHeight = 32.sp,
                         color = Neutral900,

--- a/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
@@ -64,7 +64,7 @@ fun MenuInfoBottomSheetContent(
         MenuInfoTagContent(
             modifier = Modifier
                 .fillMaxWidth(),
-            menuTags = menuInfoData.menuTags
+            menuTags = menuInfoData.menuTagImgUrls
         )
     }
 }
@@ -182,12 +182,12 @@ private fun MenuInfoBottomSheetContentPreview() {
             menuId = 1,
             menuTitle = "Test Menu",
             menuPrice = 10000,
-            menuPin = "pin",
-            menuTags = listOf("한식", "밥"),
+            menuPinImgUrl = "pin",
+            menuTagImgUrls = listOf("한식", "밥"),
             menuImgUrls = listOf(),
             menuFolderInfo = MenuFolderInfo(
                 menuFolderTitle = "Test Store",
-                menuFolderIcon = "icon",
+                menuFolderIconImgUrl = "icon",
                 menuFolderCount = 1
             ),
             mapId = 1,

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoMapScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoMapScreen.kt
@@ -65,12 +65,12 @@ fun MenuInfoMapScreen(navController: NavController) {
                     menuId = 1,
                     menuTitle = "Test Menu",
                     menuPrice = 10000,
-                    menuPin = "pin",
-                    menuTags = listOf("한식", "밥"),
+                    menuPinImgUrl = "pin",
+                    menuTagImgUrls = listOf("한식", "밥"),
                     menuImgUrls = listOf(),
                     menuFolderInfo = MenuFolderInfo(
                         menuFolderTitle = "Test Store",
-                        menuFolderIcon = "icon",
+                        menuFolderIconImgUrl = "icon",
                         menuFolderCount = 1
                     ),
                     mapId = 1,

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchBottomSheetContent.kt
@@ -40,12 +40,12 @@ private fun SearchBottomSheetContentPreview() {
                 menuId = 1,
                 menuTitle = "Test Menu",
                 menuPrice = 10000,
-                menuPin = "pin",
-                menuTags = listOf("한식", "밥"),
+                menuPinImgUrl = "pin",
+                menuTagImgUrls = listOf("한식", "밥"),
                 menuImgUrls = listOf(),
                 menuFolderInfo = MenuFolderInfo(
                     menuFolderTitle = "Test Store",
-                    menuFolderIcon = "icon",
+                    menuFolderIconImgUrl = "icon",
                     menuFolderCount = 1
                 ),
                 mapId = 1,

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/viewmodel/SearchMenuViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/viewmodel/SearchMenuViewModel.kt
@@ -267,9 +267,8 @@ class SearchMenuViewModel @Inject constructor(
             )
 
             response.onSuccess { result ->
-                if (result != null) {
+                if (result != null && result.isNotEmpty()) {
                     Log.d("SearchMenuViewModel", "등록 메뉴 정보 조회 성공: ${result.size}개")
-                    Log.d("SearchMenuViewModel", "등록 메뉴 정보 조회 성공: ${result[0].storeTitle}")
                     // 검색 결과 저장
                     _searchResult.value = result
                 }
@@ -310,6 +309,17 @@ class SearchMenuViewModel @Inject constructor(
                 }
             }.onFailure {
                 Log.d("SearchMenuViewModel", "핀 위치의 메뉴 조회 실패: ${it.message}")
+            }
+        }
+    }
+
+    fun getMapMenuDetail(menuId: Long){
+        viewModelScope.launch {
+            val response = mapRepository.getMapMenuDetail(menuId)
+            response.onSuccess {
+                Log.d("SearchMenuViewModel", "메뉴 상세 조회 성공: $it")
+            }.onFailure {
+                Log.d("SearchMenuViewModel", "메뉴 상세 조회 실패: ${it.message}")
             }
         }
     }


### PR DESCRIPTION
## 🚀 이슈번호
- #59 
## ✏️ 변경사항
- 기존 enum 사용하던 지도쪽 dto 리팩토링
- 메뉴판에 등록된 메뉴들을 지도에 표시하는 기능 구현
- 지도에서의 선택 여부에 따른 라벨 이미지 변경 구현
- 검색 결과를 BottomSheet에 반영
- 메뉴명이 10글자를 넘어가는 경우에는 ..로 문자열 처리


## 📷 스크린샷

https://github.com/user-attachments/assets/d575a5eb-7d35-454e-859d-5787ee0caea6


## ✍️ 사용법
- 지도 메뉴 선택시 메뉴판에 등록된 메뉴들을 지도에 표시해줍니다.


## 🎸 기타
- 검색 결과를 지도에 반영하기 위한 정보가 하나의 응답에서 충분하지 않은 경우가 있어 이부분은 이후에 반영해두겠습니다.
- 현재 이미지가 로딩되지 않는 것 처럼 보이는 이유는 직접 추가한 항목들이라 그렇고, 이후에 메뉴 추가 부분이 완성되면 제대로 동작할 것으로 보입니다.
