### PR TITLE
[FEAT] 지도 검색 후 메뉴 상세정보 화면으로의 이동 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -27,17 +27,6 @@
       <SelectionState runConfigName="SearchHistoryPreview">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="AddMenuScreenPreview">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-05-04T14:29:18.242220Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/casperjr/.android/avd/Medium_Phone.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapDetailResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapDetailResponse.kt
@@ -11,6 +11,8 @@ data class MapDetailResponse(
     val menuTitle: String,
     @SerialName("menuPrice")
     val menuPrice: Int,
+    @SerialName("storeTitle")
+    val storeTitle: String,
     @SerialName("menuPinImgUrl")
     val menuPinImgUrl: String,
     @SerialName("menuTagImgUrls")

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapDetailResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapDetailResponse.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MapDetailResponse(
     @SerialName("menuId")
-    val menuId: Int,
+    val menuId: Long,
     @SerialName("menuTitle")
     val menuTitle: String,
     @SerialName("menuPrice")

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapMenuDetailResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapMenuDetailResponse.kt
@@ -9,6 +9,8 @@ data class MapMenuDetailResponse(
     val menuId: Int,
     @SerialName("menuTitle")
     val menuTitle: String,
+    @SerialName("storeTitle")
+    val storeTitld: String,
     @SerialName("menuPrice")
     val menuPrice: Int,
     @SerialName("menuPinImgUrl")
@@ -20,11 +22,11 @@ data class MapMenuDetailResponse(
     @SerialName("menuFolderInfo")
     val menuFolderInfo: MenuFolderInfo,
     @SerialName("mapId")
-    val mapId: Int,
+    val mapId: Long,
     @SerialName("mapX")
-    val mapX: Int,
+    val mapX: Double,
     @SerialName("mapY")
-    val mapY: Int,
+    val mapY: Double,
 )
 
 

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapMenuDetailResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapMenuDetailResponse.kt
@@ -6,11 +6,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MapMenuDetailResponse(
     @SerialName("menuId")
-    val menuId: Int,
+    val menuId: Long,
     @SerialName("menuTitle")
     val menuTitle: String,
     @SerialName("storeTitle")
-    val storeTitld: String,
+    val storeTitle: String,
     @SerialName("menuPrice")
     val menuPrice: Int,
     @SerialName("menuPinImgUrl")

--- a/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapSearchHistoryResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/map/response/MapSearchHistoryResponse.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MapSearchHistoryResponse(
     @SerialName("menuId")
-    val menuId: Int,
+    val menuId: Long,
     @SerialName("menuTitle")
     val menuTitle: String,
     @SerialName("storeTitle")

--- a/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderAllResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderAllResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MenuFolderAllResponse(
-    override val menuId: Int,
+    override val menuId: Long,
     override val menuTitle: String,
     override val storeTitle: String,
     override val storeAddress: String,

--- a/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderDetailResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderDetailResponse.kt
@@ -13,7 +13,7 @@ data class MenuFolderDetailResponse(
 
 @Serializable
 data class MenuFolderDetailMenus(
-    override val menuId: Int = 0,
+    override val menuId: Long = 0,
     override val menuTitle: String = "",
     override val storeTitle: String = "",
     override val storeAddress: String = "",

--- a/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderMenuItem.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderMenuItem.kt
@@ -1,7 +1,7 @@
 package com.kuit.ourmenu.data.model.menuFolder.response
 
 interface MenuFolderMenuItem {
-    val menuId: Int
+    val menuId: Long
     val menuTitle: String
     val storeTitle: String
     val storeAddress: String

--- a/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/response/MenuFolderResponse.kt
@@ -10,7 +10,7 @@ data class MenuFolderResponse(
 
 @Serializable
 data class MenuFolderList(
-    val menuFolderId: Int,
+    val menuFolderId: Long,
     val menuFolderTitle: String,
     val menuFolderImgUrl: String,
     val menuFolderIconImgUrl: String,

--- a/app/src/main/java/com/kuit/ourmenu/data/model/menuinfo/response/MenuInfoResponse.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/menuinfo/response/MenuInfoResponse.kt
@@ -4,10 +4,12 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MenuInfoResponse(
-    val menuId: Int = 0,
+    val menuId: Long = 0,
     val menuTitle: String = "",
     val menuPrice: Int = 0,
     val menuPinImgUrl: String = "",
+    val menuMemoTitle: String = "",
+    val menuMemoContent: String = "",
     val storeTitle: String = "",
     val storeAddress: String = "",
     val tagImgUrls: List<String> = emptyList(),

--- a/app/src/main/java/com/kuit/ourmenu/data/repository/MenuFolderRepository.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/repository/MenuFolderRepository.kt
@@ -14,7 +14,7 @@ class MenuFolderRepository @Inject constructor(
     }
 
     suspend fun getMenuFolderDetail(
-        menuFolderId: Int,
+        menuFolderId: Long,
         sortOrder: String,
     ) = runCatching {
         menuFolderService.getMenuFolderDetails(

--- a/app/src/main/java/com/kuit/ourmenu/data/repository/MenuInfoRepository.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/repository/MenuInfoRepository.kt
@@ -10,7 +10,7 @@ class MenuInfoRepository @Inject constructor(
     private val menuInfoService: MenuInfoService
 ) {
     suspend fun getMenuInfo(
-        menuId: Int
+        menuId: Long
     ) = runCatching {
         menuInfoService.getMenuInfo(menuId).handleBaseResponse().getOrThrow()
     }

--- a/app/src/main/java/com/kuit/ourmenu/data/service/MapService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/MapService.kt
@@ -18,15 +18,15 @@ interface MapService {
     @GET("api/users/menus/{mapId}/maps")
     suspend fun getMapDetail(
         @Path("mapId") mapId: Long
-    ): BaseResponse<List<MapDetailResponse>> // TODO: 리팩토링
+    ): BaseResponse<List<MapDetailResponse>>
 
     @GET("api/users/menus/maps")
-    suspend fun getMap(): BaseResponse<List<MapResponse>> // TODO: 리팩토링
+    suspend fun getMap(): BaseResponse<List<MapResponse>>
 
     @GET("api/users/menus/maps/{menuId}/search")
     suspend fun getMapMenuDetail(
         @Path("menuId") menuId: Long
-    ): BaseResponse<MapMenuDetailResponse> // TODO: 리팩토링
+    ): BaseResponse<MapMenuDetailResponse>
 
     @GET("api/users/menus/maps/search")
     suspend fun getMapSearch(

--- a/app/src/main/java/com/kuit/ourmenu/data/service/MenuFolderService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/MenuFolderService.kt
@@ -14,7 +14,7 @@ interface MenuFolderService {
 
     @GET("api/menu-folders/{menuFolderId}/menus")
     suspend fun getMenuFolderDetails(
-        @Path("menuFolderId") menuFolderId: Int,
+        @Path("menuFolderId") menuFolderId: Long,
         @Query("sortOrder") sortOrder: String,
     ): BaseResponse<MenuFolderDetailResponse>
 

--- a/app/src/main/java/com/kuit/ourmenu/data/service/MenuInfoService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/MenuInfoService.kt
@@ -8,6 +8,6 @@ import retrofit2.http.Path
 interface MenuInfoService {
     @GET("api/menus/{menuId}")
     suspend fun getMenuInfo(
-        @Path("menuId") menuId: Int
+        @Path("menuId") menuId: Long
     ): BaseResponse<MenuInfoResponse>
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
@@ -114,7 +114,7 @@ fun MenuInfoContent(
             )
         }
         Text(
-            text = "응답에 가게명 누락", // TODO: 가게명 처리
+            text = menuInfoData.storeTitle,
             style = ourMenuTypography().pretendard_600_14.copy(
                 lineHeight = 12.sp,
                 color = Neutral500
@@ -187,6 +187,7 @@ private fun MenuInfoBottomSheetContentPreview() {
         menuInfoData = MapDetailResponse(
             menuId = 1,
             menuTitle = "Test Menu",
+            storeTitle = "가게 이름",
             menuPrice = 10000,
             menuPinImgUrl = "pin",
             menuTagImgUrls = listOf("한식", "밥"),

--- a/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/common/bottomsheet/MenuInfoBottomSheetContent.kt
@@ -1,6 +1,8 @@
 package com.kuit.ourmenu.ui.common.bottomsheet
 
+import android.util.Log
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,12 +40,17 @@ import com.kuit.ourmenu.utils.ExtensionUtil.toWon
 @Composable
 fun MenuInfoBottomSheetContent(
     modifier: Modifier = Modifier,
-    menuInfoData: MapDetailResponse
+    menuInfoData: MapDetailResponse,
+    onClick: (Long) -> Unit
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp)
+            .clickable {
+                Log.d("MenuInfoBottomSheetContent", "Menu ID: ${menuInfoData.menuId}")
+                onClick(menuInfoData.menuId)
+            }
     ) {
         MenuInfoContent(
             modifier = Modifier
@@ -201,5 +208,7 @@ private fun MenuInfoBottomSheetContentPreview() {
             mapX = 127.0,
             mapY = 37.0
         )
-    )
+    ){
+        // 클릭시 동작
+    }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
@@ -34,9 +34,9 @@ fun NavController.navigateToMenuInfo(menuId: Long) {
 
 fun NavGraphBuilder.menuFolderNavGraph(
     navigateBack: () -> Unit,
-    navigateToMenuFolderDetail: (Int) -> Unit,
+    navigateToMenuFolderDetail: (Long) -> Unit,
     navigateToMenuFolderAllMenu: () -> Unit,
-    navigateToMenuInfo: (Int) -> Unit,
+    navigateToMenuInfo: (Long) -> Unit,
     navigateToAddMenu: () -> Unit,
 ) {
     composable<MainTabRoute.MenuFolder> {

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
@@ -16,7 +16,7 @@ fun NavController.navigateToMenuFolder(navOptions: NavOptions) {
 }
 
 // 이동 이벤트 (menuFolderId 전달)
-fun NavController.navigateToMenuFolderDetail(menuFolderId: Int) {
+fun NavController.navigateToMenuFolderDetail(menuFolderId: Long) {
     navigate(Routes.MenuFolderDetail(menuFolderId))
 }
 
@@ -28,7 +28,7 @@ fun NavController.navigateToAddMenu() {
     navigate(Routes.AddMenu)
 }
 
-fun NavController.navigateToMenuInfo(menuId: Int) {
+fun NavController.navigateToMenuInfo(menuId: Long) {
     navigate(Routes.MenuInfo(menuId))
 }
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderAllMenuScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderAllMenuScreen.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun MenuFolderAllMenuScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToMenuInfo: (Int) -> Unit,
+    onNavigateToMenuInfo: (Long) -> Unit,
 //    onNavigateToMap: () -> Unit, // TODO: Map으로 화면 이동 구현
     onNavigateToAddMenu: () -> Unit,
     viewModel: MenuFolderAllViewModel = hiltViewModel()

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderDetailScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderDetailScreen.kt
@@ -46,7 +46,7 @@ import com.kuit.ourmenu.ui.theme.ourMenuTypography
 @Composable
 fun MenuFolderDetailScreen(
     menuFolderId: Long,
-    onNavigateToMenuInfo: (Int) -> Unit,
+    onNavigateToMenuInfo: (Long) -> Unit,
 //    onNavigateToMap: () -> Unit, // TODO: Map으로 화면 이동 구현
     onNavigateToAddMenu: () -> Unit,
     onNavigateBack: () -> Unit,

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderDetailScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderDetailScreen.kt
@@ -45,7 +45,7 @@ import com.kuit.ourmenu.ui.theme.ourMenuTypography
 
 @Composable
 fun MenuFolderDetailScreen(
-    menuFolderId: Int,
+    menuFolderId: Long,
     onNavigateToMenuInfo: (Int) -> Unit,
 //    onNavigateToMap: () -> Unit, // TODO: Map으로 화면 이동 구현
     onNavigateToAddMenu: () -> Unit,

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
@@ -37,7 +37,7 @@ import com.kuit.ourmenu.ui.theme.ourMenuTypography
 
 @Composable
 fun MenuFolderScreen(
-    onNavigateToDetail: (Int) -> Unit,
+    onNavigateToDetail: (Long) -> Unit,
     onNavigateToAllMenu: () -> Unit,
     onNavigateToAddMenu: () -> Unit,
     viewModel: MenuFolderViewModel = hiltViewModel()

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderDetailViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderDetailViewModel.kt
@@ -18,7 +18,7 @@ class MenuFolderDetailViewModel @Inject constructor(
     private val _menuFolderDetail = MutableStateFlow(MenuFolderDetailResponse())
     val menuFolderDetail = _menuFolderDetail.asStateFlow()
 
-    private val _menuFolderId = MutableStateFlow(0)
+    private val _menuFolderId = MutableStateFlow<Long>(0)
     val menuFolderId = _menuFolderId.asStateFlow()
 
     private val _sortOrder = MutableStateFlow(SortOrderType.TITLE_ASC)
@@ -31,7 +31,7 @@ class MenuFolderDetailViewModel @Inject constructor(
     val isLoading = _isLoading.asStateFlow()
 
     fun getMenuFolderDetail(
-        menuFolderId: Int,
+        menuFolderId: Long,
         sortOrder: SortOrderType = _sortOrder.value
     ) {
         _menuFolderId.value = menuFolderId
@@ -57,7 +57,7 @@ class MenuFolderDetailViewModel @Inject constructor(
         }
     }
 
-    fun updateSortOrder(sortOrderType: SortOrderType, menuFolderId: Int) {
+    fun updateSortOrder(sortOrderType: SortOrderType, menuFolderId: Long) {
         if (_sortOrder.value != sortOrderType) {
             _sortOrder.value = sortOrderType
             getMenuFolderDetail(menuFolderId, sortOrderType)

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/navigation/MenuInfoNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/navigation/MenuInfoNavigation.kt
@@ -7,13 +7,13 @@ import androidx.navigation.toRoute
 import com.kuit.ourmenu.ui.menuinfo.screen.MenuInfoDefaultScreen
 import com.kuit.ourmenu.ui.navigator.Routes
 
-fun NavController.navigateToMenuInfo(menuId: Int) {
+fun NavController.navigateToMenuInfo(menuId: Long) {
     navigate(Routes.MenuInfo(menuId))
 }
 
 fun NavGraphBuilder.menuInfoNavGraph(
     navigateBack: () -> Unit,
-    navigateToMenuFolderDetail: (Int) -> Unit,
+    navigateToMenuFolderDetail: (Long) -> Unit,
     navigateToMenuInfoMap: () -> Unit
 ) {
     composable<Routes.MenuInfo> {

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoDefaultScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoDefaultScreen.kt
@@ -23,16 +23,15 @@ import com.kuit.ourmenu.ui.menuinfo.component.info.MenuInfoChipContent
 import com.kuit.ourmenu.ui.menuinfo.component.info.MenuInfoContent
 import com.kuit.ourmenu.ui.menuinfo.component.info.MenuInfoImagePager
 import com.kuit.ourmenu.ui.menuinfo.component.info.MenuInfoMapButton
-import com.kuit.ourmenu.ui.menuinfo.dummy.MenuInfoDummyData
 import com.kuit.ourmenu.ui.menuinfo.viewmodel.MenuInfoViewModel
 import com.kuit.ourmenu.ui.theme.Neutral300
 import com.kuit.ourmenu.ui.theme.NeutralWhite
 
 @Composable
 fun MenuInfoDefaultScreen(
-    menuId: Int,
+    menuId: Long,
     onNavigateBack: () -> Unit,
-    onNavigateToMenuFolderDetail: (Int) -> Unit,
+    onNavigateToMenuFolderDetail: (Long) -> Unit,
 //    onNavigateToMap: () -> Unit,
     viewModel: MenuInfoViewModel = hiltViewModel()
 ) {
@@ -73,15 +72,15 @@ fun MenuInfoDefaultScreen(
                     )
 
                     MenuInfoChipContent(
-                        onNavigateToMenuFolderDetail = onNavigateToMenuFolderDetail,
+                        // TODO: 메뉴 폴더 정보에 따라 변경 필요, 여러개인 경우 각 폴더에 대한 이동 구현
+//                        onNavigateToMenuFolderDetail = onNavigateToMenuFolderDetail(menuInfo.menuFolders.),
                         menuInfoData = menuInfo
                     )
 
                     MenuInfoAdditionalContent(
                         address = menuInfo.storeAddress,
-                        // TODO: 메뉴 정보에 따라 변경 필요
-                        memoTitle = MenuInfoDummyData.dummyData.memoTitle,
-                        memoContent = MenuInfoDummyData.dummyData.memoContent
+                        memoTitle = menuInfo.menuMemoTitle,
+                        memoContent = menuInfo.menuMemoContent
                     )
                 }
                 MenuInfoMapButton(
@@ -105,4 +104,11 @@ private fun MenuInfoDefaultPreview() {
 //    val navController = rememberNavController()
 //
 //    MenuInfoDefaultScreen(navController)
+    val viewModel: MenuInfoViewModel = hiltViewModel()
+    MenuInfoDefaultScreen(
+        menuId = 1,
+        onNavigateBack = {},
+        onNavigateToMenuFolderDetail = {},
+        viewModel = viewModel
+    )
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoMapScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoMapScreen.kt
@@ -78,7 +78,9 @@ fun MenuInfoMapScreen(navController: NavController) {
                     mapX = 127.0,
                     mapY = 37.0
                 )
-            )
+            ){
+
+            }
         },
         sheetPeekHeight = bottomSheetContentHeight,
     ) { innerPaddings ->

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoMapScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/screen/MenuInfoMapScreen.kt
@@ -64,6 +64,7 @@ fun MenuInfoMapScreen(navController: NavController) {
                 menuInfoData = MapDetailResponse(
                     menuId = 1,
                     menuTitle = "Test Menu",
+                    storeTitle = "가게 이름",
                     menuPrice = 10000,
                     menuPinImgUrl = "pin",
                     menuTagImgUrls = listOf("한식", "밥"),

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/viewmodel/MenuInfoViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuinfo/viewmodel/MenuInfoViewModel.kt
@@ -17,7 +17,7 @@ class MenuInfoViewModel @Inject constructor(
     private val _menuInfo = MutableStateFlow(MenuInfoResponse())
     val menuInfo = _menuInfo.asStateFlow()
 
-    private val _menuId = MutableStateFlow(0)
+    private val _menuId = MutableStateFlow<Long>(0)
     val menuId = _menuId.asStateFlow()
 
     private val _error: MutableStateFlow<String?> = MutableStateFlow(null)
@@ -27,7 +27,7 @@ class MenuInfoViewModel @Inject constructor(
     val isLoading = _isLoading.asStateFlow()
 
     fun getMenuInfo(
-        menuId: Int
+        menuId: Long
     ) {
         _menuId.value = menuId
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
@@ -95,7 +95,7 @@ class MainNavController(
     }
 
     // Menu Folder
-    fun navigateToMenuFolderDetail(menuFolderId: Int) {
+    fun navigateToMenuFolderDetail(menuFolderId: Long) {
         navController.navigateToMenuFolderDetail(menuFolderId)
     }
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
@@ -106,6 +106,7 @@ class MainNavController(
     // My
     fun navigateToEditMyMealTime(selectedTimes: List<Int>) {
         navController.navigateToEditMyMealTime(selectedTimes)
+    }
 
     // Add Menu
     fun navigateToAddMenu() {

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavController.kt
@@ -118,7 +118,7 @@ class MainNavController(
     }
 
     // Menu Info
-    fun navigateToMenuInfo(menuId: Int) {
+    fun navigateToMenuInfo(menuId: Long) {
         navController.navigateToMenuInfo(menuId)
     }
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
@@ -73,7 +73,7 @@ fun MainNavHost(
         )
 
         searchMenuNavGraph(
-            padding = padding,
+            navigateToMenuDetail = navController::navigateToMenuInfo,
         )
 
         myNavGraph(

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/Routes.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/Routes.kt
@@ -8,13 +8,13 @@ sealed interface Routes{
     @Serializable
     data object MenuFolder: Routes
     @Serializable
-    data class MenuFolderDetail(val menuFolderId: Int): Routes
+    data class MenuFolderDetail(val menuFolderId: Long): Routes
     @Serializable
     data object MenuFolderAllMenu: Routes
 
     // 메뉴
     @Serializable
-    data class MenuInfo(val menuId: Int): Routes
+    data class MenuInfo(val menuId: Long): Routes
     @Serializable
     data object MenuInfoMap: Routes
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchBottomSheetContent.kt
@@ -14,7 +14,8 @@ import com.kuit.ourmenu.ui.common.bottomsheet.MenuInfoBottomSheetContent
 @Composable
 fun SearchBottomSheetContent(
     modifier: Modifier = Modifier,
-    dataList: List<MapDetailResponse>
+    dataList: List<MapDetailResponse>,
+    onItemClick: (Long) -> Unit
 ) {
     LazyColumn(
         modifier = modifier
@@ -22,7 +23,10 @@ fun SearchBottomSheetContent(
         items(dataList.size) { index ->
             MenuInfoBottomSheetContent(
                 modifier = Modifier.padding(vertical = 20.dp),
-                menuInfoData = dataList[index]
+                menuInfoData = dataList[index],
+                onClick = { menuId -> 
+                    onItemClick(menuId)
+                }
             )
             if (index != dataList.size - 1) {
                 HorizontalDivider()
@@ -54,5 +58,7 @@ private fun SearchBottomSheetContentPreview() {
                 mapY = 37.0
             )
         )
-    )
+    ){
+
+    }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchBottomSheetContent.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchBottomSheetContent.kt
@@ -39,6 +39,7 @@ private fun SearchBottomSheetContentPreview() {
             MapDetailResponse(
                 menuId = 1,
                 menuTitle = "Test Menu",
+                storeTitle = "가게 이름",
                 menuPrice = 10000,
                 menuPinImgUrl = "pin",
                 menuTagImgUrls = listOf("한식", "밥"),

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchHistory.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchHistory.kt
@@ -33,7 +33,7 @@ import com.kuit.ourmenu.ui.theme.ourMenuTypography
 fun SearchHistoryList(
     modifier: Modifier = Modifier,
     historyList: List<MapSearchHistoryResponse>?,
-    onClick: () -> Unit = {},
+    onClick: (Long) -> Unit = {},
 ) {
     val lazyListState = rememberLazyListState()
 
@@ -99,13 +99,13 @@ fun SearchHistoryList(
 fun SearchHistoryItem(
     modifier: Modifier = Modifier,
     historyData: MapSearchHistoryResponse,
-    onClick: () -> Unit
+    onClick: (Long) -> Unit
 ) {
 
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(onClick = { onClick(historyData.menuId) })
             .padding(vertical = 20.dp, horizontal = 28.dp)
     ) {
         Text(

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchHistory.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/component/SearchHistory.kt
@@ -23,7 +23,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kuit.ourmenu.R
-import com.kuit.ourmenu.ui.searchmenu.model.SearchHistoryData
+import com.kuit.ourmenu.data.model.map.response.MapSearchHistoryResponse
+import com.kuit.ourmenu.ui.theme.Neutral300
 import com.kuit.ourmenu.ui.theme.Neutral500
 import com.kuit.ourmenu.ui.theme.Neutral700
 import com.kuit.ourmenu.ui.theme.ourMenuTypography
@@ -31,8 +32,8 @@ import com.kuit.ourmenu.ui.theme.ourMenuTypography
 @Composable
 fun SearchHistoryList(
     modifier: Modifier = Modifier,
+    historyList: List<MapSearchHistoryResponse>?,
     onClick: () -> Unit = {},
-    historyList: List<SearchHistoryData>
 ) {
     val lazyListState = rememberLazyListState()
 
@@ -41,28 +42,53 @@ fun SearchHistoryList(
             .fillMaxWidth()
             .padding(top = 68.dp)
     ) {
-        Text(
-            text = "최근 검색",
-            style = ourMenuTypography().pretendard_600_16.copy(
-                lineHeight = 20.sp,
-                color = Neutral700
-            ),
-            modifier = modifier
-                .padding(bottom = 4.dp)
-                .padding(horizontal = 28.dp)
-        )
-        LazyColumn(
-            state = lazyListState
-        ) {
-
-            items(historyList.size) { index ->
-                SearchHistoryItem(
-                    historyData = historyList[index],
-                    onClick = onClick
+        if (historyList == null || historyList.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 68.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_addmenu_noresult),
+                    contentDescription = "no result",
+                    tint = Color.Unspecified
                 )
+                Text(
+                    text = stringResource(R.string.no_result),
+                    style = ourMenuTypography().pretendard_600_14,
+                    color = Neutral500,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        } else {
+            Text(
+                text = "최근 검색",
+                style = ourMenuTypography().pretendard_600_16.copy(
+                    lineHeight = 20.sp,
+                    color = Neutral700
+                ),
+                modifier = modifier
+                    .padding(bottom = 4.dp)
+                    .padding(horizontal = 28.dp)
+            )
+            LazyColumn(
+                state = lazyListState
+            ) {
 
-                if (index != historyList.size - 1) {
-                    HorizontalDivider()
+                items(historyList.size) { index ->
+                    SearchHistoryItem(
+                        historyData = historyList[index],
+                        onClick = onClick
+                    )
+
+                    if (index != historyList.size - 1) {
+                        HorizontalDivider(
+                            thickness = 1.dp,
+                            color = Neutral300,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
         }
@@ -72,7 +98,7 @@ fun SearchHistoryList(
 @Composable
 fun SearchHistoryItem(
     modifier: Modifier = Modifier,
-    historyData: SearchHistoryData,
+    historyData: MapSearchHistoryResponse,
     onClick: () -> Unit
 ) {
 
@@ -115,7 +141,7 @@ fun SearchHistoryItem(
                         .wrapContentHeight(align = Alignment.CenterVertically)
                 )
                 Text(
-                    text = stringResource(R.string.neungdongro_112),
+                    text = historyData.storeAddress,
                     style = ourMenuTypography().pretendard_600_14.copy(
                         lineHeight = 20.sp,
                         color = Neutral500
@@ -135,20 +161,23 @@ fun SearchHistoryItem(
 private fun SearchHistoryPreview() {
     SearchHistoryList(
         historyList = listOf(
-            SearchHistoryData(
+            MapSearchHistoryResponse(
                 menuTitle = "피자",
                 storeTitle = "피자헛",
-                address = "서울특별시 강남구 역삼동 123-4"
+                menuId = 1,
+                storeAddress = "서울특별시 강남구 역삼동 123-4"
             ),
-            SearchHistoryData(
+            MapSearchHistoryResponse(
                 menuTitle = "치킨",
                 storeTitle = "굽네치킨",
-                address = "서울특별시 강남구 역삼동 123-4"
+                menuId = 2,
+                storeAddress = "서울특별시 강남구 역삼동 456-7"
             ),
-            SearchHistoryData(
+            MapSearchHistoryResponse(
                 menuTitle = "햄버거",
                 storeTitle = "맥도날드",
-                address = "서울특별시 강남구 역삼동 123-4"
+                menuId = 3,
+                storeAddress = "서울특별시 강남구 역삼동 987-6"
             )
         ),
     )

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/navigation/SearchMenuNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/navigation/SearchMenuNavigation.kt
@@ -1,6 +1,5 @@
 package com.kuit.ourmenu.ui.searchmenu.navigation
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -13,10 +12,12 @@ fun NavController.navigateToSearchMenu(navOptions: NavOptions) {
 }
 
 fun NavGraphBuilder.searchMenuNavGraph(
-    padding: PaddingValues,
     // navigate 이벤트
+    navigateToMenuDetail: (Long) -> Unit,
 ) {
     composable<MainTabRoute.Map> {
-        SearchMenuScreen()
+        SearchMenuScreen(
+            onNavigateToMenuDetail = navigateToMenuDetail
+        )
     }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -69,13 +68,13 @@ fun SearchMenuScreen(
     val locationPermissionGranted by viewModel.locationPermissionGranted.collectAsStateWithLifecycle()
 
     // 지도 중심 좌표
-    val currentCenter by viewModel.currentCenter.collectAsState()
+    val currentCenter by viewModel.currentCenter.collectAsStateWithLifecycle()
     
     // 검색기록
-    val searchHistory by viewModel.searchHistory.collectAsState()
+    val searchHistory by viewModel.searchHistory.collectAsStateWithLifecycle()
     
     // 핀 위치에 해당하는 메뉴들
-    val menusOnPin by viewModel.menusOnPin.collectAsState()
+    val menusOnPin by viewModel.menusOnPin.collectAsStateWithLifecycle()
 
     val density = LocalDensity.current
     val singleItemHeight = 300.dp // Fixed height for each item

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
@@ -181,8 +181,10 @@ fun SearchMenuScreen(
             } else {
                 SearchHistoryList(
                     historyList = searchHistory,
-                    onClick = {
+                    onClick = { menuId ->
                         // 크롤링 기록 아이템 클릭시 동작
+                        viewModel.getMapMenuDetail(menuId)
+                        Log.d("SearchMenuScreen", "검색 기록 아이템 클릭: $menuId")
                         showSearchBackground = false
                         showBottomSheet = true
                     }

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/screen/SearchMenuScreen.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.launch
 fun SearchMenuScreen(
     modifier: Modifier = Modifier,
     viewModel: SearchMenuViewModel = hiltViewModel(),
+    onNavigateToMenuDetail: (Long) -> Unit
 ) {
 
     val scaffoldState = rememberBottomSheetScaffoldState()
@@ -143,7 +144,11 @@ fun SearchMenuScreen(
         sheetContent = {
             SearchBottomSheetContent(
                 modifier = Modifier.fillMaxWidth(),
-                dataList = menusOnPin ?: emptyList()
+                dataList = menusOnPin ?: emptyList(),
+                onItemClick = { menuId ->
+                    Log.d("SearchMenuScreen", "바텀 시트 메뉴 아이템 클릭: $menuId")
+                    onNavigateToMenuDetail(menuId)
+                }
             )
         },
         sheetContainerColor = NeutralWhite,
@@ -246,5 +251,8 @@ fun SearchMenuScreen(
 @Preview(showBackground = true)
 @Composable
 private fun SearchMenuScreenPreview() {
-    SearchMenuScreen()
+    SearchMenuScreen(
+    ){
+
+    }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/viewmodel/SearchMenuViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/searchmenu/viewmodel/SearchMenuViewModel.kt
@@ -313,11 +313,22 @@ class SearchMenuViewModel @Inject constructor(
         }
     }
 
-    fun getMapMenuDetail(menuId: Long){
+    fun getMapMenuDetail(menuId: Long) {
         viewModelScope.launch {
             val response = mapRepository.getMapMenuDetail(menuId)
-            response.onSuccess {
-                Log.d("SearchMenuViewModel", "메뉴 상세 조회 성공: $it")
+            response.onSuccess { menuDetail ->
+                Log.d("SearchMenuViewModel", "메뉴 상세 조회 성공: $menuDetail")
+                
+                // myMenus에서 해당 menuId를 가진 메뉴의 위치 정보 찾기
+                myMenus.value?.find { it.mapId == menuId }?.let { menu ->
+                    // 해당 위치로 카메라 이동
+                    moveCamera(menu.mapY, menu.mapX)
+                    // 해당 핀을 활성화 상태로 변경
+                    _activeMapId.value = menuId
+                    refreshMarkers()
+                    // 메뉴 상세 정보를 바텀시트에 표시하기 위해 설정
+                    getMapDetail(menuId)
+                }
             }.onFailure {
                 Log.d("SearchMenuViewModel", "메뉴 상세 조회 실패: ${it.message}")
             }


### PR DESCRIPTION
## 🚀 이슈번호
- #59 

## ✏️ 변경사항
- SearchMenuScreen에서의 collectAsState -> collectAsStateWithLifecycle로 리팩토일
- 검색 결과 dto에 가게명 추가
- 각종 id 값들 Int -> Long으로 수정
- 등록한 메뉴 검색 이후 BottomSheet의 아이템 클릭시 메뉴 상세 화면으로 이동

## 📷 스크린샷

https://github.com/user-attachments/assets/504170b4-ae97-4de4-9e57-83f4ac60da8f


## ✍️ 사용법



## 🎸 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 검색 바텀시트·최근 검색 항목 탭 시 메뉴 상세로 바로 이동
  - 지도 바텀시트에서 매장명 표시 및 전체 영역 클릭 동작 지원
- Improvements
  - 메뉴 상세에 메모 제목/내용과 이미지 목록 표시로 정보 강화
  - 최근 검색 비어 있을 때 안내 UI 추가
  - 수명주기 연동으로 검색/지도 데이터 갱신 안정화
- UI
  - 리스트 구분선 두께/색상 등 시각적 디테일 개선
- Chores
  - 대용량 ID 대응을 위한 내부 타입 정리 및 네비게이션 연동 정비
  - 불필요한 주석/설정 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->