### PR TITLE
[FEAT] 메뉴판 삭제, 순서변경 Api 구현

### DIFF
--- a/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/request/MenuFolderIndexRequest.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/model/menuFolder/request/MenuFolderIndexRequest.kt
@@ -1,0 +1,8 @@
+package com.kuit.ourmenu.data.model.menuFolder.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MenuFolderIndexRequest(
+    val index: Int,
+)

--- a/app/src/main/java/com/kuit/ourmenu/data/repository/MenuFolderRepository.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/repository/MenuFolderRepository.kt
@@ -40,4 +40,10 @@ class MenuFolderRepository @Inject constructor(
             sortOrder = sortOrder
         ).handleBaseResponse().getOrThrow()
     }
+
+    suspend fun deleteMenuFolder(
+        menuFolderId: Long
+    ) = runCatching {
+        menuFolderService.deleteMenuFolder(menuFolderId).handleBaseResponse().getOrThrow()
+    }
 }

--- a/app/src/main/java/com/kuit/ourmenu/data/repository/MenuFolderRepository.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/repository/MenuFolderRepository.kt
@@ -1,6 +1,7 @@
 package com.kuit.ourmenu.data.repository
 
 import com.kuit.ourmenu.data.model.base.handleBaseResponse
+import com.kuit.ourmenu.data.model.menuFolder.request.MenuFolderIndexRequest
 import com.kuit.ourmenu.data.service.MenuFolderService
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -45,5 +46,15 @@ class MenuFolderRepository @Inject constructor(
         menuFolderId: Long
     ) = runCatching {
         menuFolderService.deleteMenuFolder(menuFolderId).handleBaseResponse().getOrThrow()
+    }
+
+    suspend fun updateMenuFolderIndex(
+        menuFolderId: Long,
+        request: MenuFolderIndexRequest
+    ) = runCatching {
+        menuFolderService.updateMenuFolderIndex(
+            menuFolderId = menuFolderId,
+            request = request
+        ).handleBaseResponse().getOrThrow()
     }
 }

--- a/app/src/main/java/com/kuit/ourmenu/data/service/MenuFolderService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/MenuFolderService.kt
@@ -4,6 +4,7 @@ import com.kuit.ourmenu.data.model.base.BaseResponse
 import com.kuit.ourmenu.data.model.menuFolder.response.MenuFolderAllResponse
 import com.kuit.ourmenu.data.model.menuFolder.response.MenuFolderDetailResponse
 import com.kuit.ourmenu.data.model.menuFolder.response.MenuFolderResponse
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -27,4 +28,9 @@ interface MenuFolderService {
         @Query("size") size: Int,
         @Query("sortOrder") sortOrder: String,
     ): BaseResponse<List<MenuFolderAllResponse>>
+
+    @DELETE("api/menu-folders/{menuFolderId}")
+    suspend fun deleteMenuFolder(
+        @Path("menuFolderId") menuFolderId: Long
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/kuit/ourmenu/data/service/MenuFolderService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/MenuFolderService.kt
@@ -1,11 +1,14 @@
 package com.kuit.ourmenu.data.service
 
 import com.kuit.ourmenu.data.model.base.BaseResponse
+import com.kuit.ourmenu.data.model.menuFolder.request.MenuFolderIndexRequest
 import com.kuit.ourmenu.data.model.menuFolder.response.MenuFolderAllResponse
 import com.kuit.ourmenu.data.model.menuFolder.response.MenuFolderDetailResponse
 import com.kuit.ourmenu.data.model.menuFolder.response.MenuFolderResponse
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -33,4 +36,10 @@ interface MenuFolderService {
     suspend fun deleteMenuFolder(
         @Path("menuFolderId") menuFolderId: Long
     ): BaseResponse<Unit>
+
+    @PATCH("api/menu-folders/{menuFolderId}/index")
+    suspend fun updateMenuFolderIndex(
+        @Path("menuFolderId") menuFolderId: Long,
+        @Body request: MenuFolderIndexRequest
+    ): BaseResponse<MenuFolderDetailResponse>
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/component/DeleteMenuFolderModal.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/component/DeleteMenuFolderModal.kt
@@ -1,0 +1,143 @@
+package com.kuit.ourmenu.ui.menuFolder.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.kuit.ourmenu.R
+import com.kuit.ourmenu.ui.my.component.LogoutModal
+import com.kuit.ourmenu.ui.theme.Neutral400
+import com.kuit.ourmenu.ui.theme.Neutral500
+import com.kuit.ourmenu.ui.theme.Neutral900
+import com.kuit.ourmenu.ui.theme.NeutralWhite
+import com.kuit.ourmenu.ui.theme.Primary500Main
+import com.kuit.ourmenu.ui.theme.ourMenuTypography
+
+@Composable
+fun DeleteMenuFolderModal(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .background(NeutralWhite, shape = RoundedCornerShape(16.dp))
+                .padding(20.dp)
+                .width(288.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // 닫기 아이콘
+            Icon(
+                painter = painterResource(R.drawable.ic_close_24_n400),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .clickable { onDismiss() }
+                    .size(24.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // 제목
+            Text(
+                text = stringResource(R.string.delete_menu_folder_modal_title),
+                style = ourMenuTypography().pretendard_700_18,
+                color = Neutral900,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = stringResource(R.string.delete_menu_folder_modal_content),
+                style = ourMenuTypography().pretendard_500_14,
+                color = Neutral500,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 버튼 Row
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+
+                Button(
+                    onClick = {
+                        onConfirm()
+                        onDismiss()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Primary500Main,
+                        contentColor = NeutralWhite
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.delete),
+                        style = ourMenuTypography().pretendard_700_18,
+                        color = NeutralWhite
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Button(
+                    onClick = {
+                        onDismiss()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Neutral400,
+                        contentColor = NeutralWhite
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.cancel),
+                        style = ourMenuTypography().pretendard_700_18,
+                        color = NeutralWhite
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DeleteMenuFolderModalPreview() {
+    DeleteMenuFolderModal(
+        onDismiss = {},
+        onConfirm = {}
+    )
+}

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/component/MenuFolderButton.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/component/MenuFolderButton.kt
@@ -50,6 +50,7 @@ import kotlin.math.roundToInt
 
 @Composable
 fun MenuFolderButton(
+    modifier: Modifier = Modifier,
     menuFolder: MenuFolderList,
     isSwiped: Boolean, // 현재 버튼이 스와이프된 상태인지 확인
     onSwipe: () -> Unit, // 새로운 버튼이 스와이프될 때 호출
@@ -74,7 +75,7 @@ fun MenuFolderButton(
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .height(132.dp)
             .fillMaxWidth()
             .pointerInput(Unit) {
@@ -278,6 +279,7 @@ private fun MenuFolderButtonPreview() {
     )
 
     MenuFolderButton(
+        modifier = Modifier,
         menuFolder = dummyMenuFolder,
         false, {}, {})
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/component/MenuFolderButton.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/component/MenuFolderButton.kt
@@ -1,5 +1,6 @@
 package com.kuit.ourmenu.ui.menuFolder.component
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -19,11 +20,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,9 +30,11 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.kuit.ourmenu.R
@@ -44,6 +45,7 @@ import com.kuit.ourmenu.ui.theme.NeutralWhite
 import com.kuit.ourmenu.ui.theme.Primary500Main
 import com.kuit.ourmenu.ui.theme.ourMenuTypography
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 
 @Composable
@@ -56,31 +58,64 @@ fun MenuFolderButton(
     onEditClick: () -> Unit = {},
     onDeleteClick: () -> Unit = {}
 ) {
-    var offsetX by remember { mutableFloatStateOf(0f) }
+    val density = LocalDensity.current
+    val offset = remember {
+        Animatable(initialValue = 0f)
+    }
     val scope = rememberCoroutineScope()
-    val maxSwipe = 128f // 최대 스와이프 범위 (삭제 + 수정 버튼 너비)
+    val maxSwipe = with(density) {
+        128.dp.toPx() // 최대 스와이프 범위를 dp에서 px로 변환
+    }
+
+    LaunchedEffect(isSwiped) {
+        if (!isSwiped) {
+            offset.snapTo(0f)
+        }
+    }
 
     Box(
         modifier = Modifier
             .height(132.dp)
             .fillMaxWidth()
             .pointerInput(Unit) {
+//                detectHorizontalDragGestures(
+//                    onDragEnd = {
+//                        scope.launch {
+//                            if (offsetX < -80f) {
+//                                onSwipe() // 다른 버튼을 닫고 이 버튼만 스와이프
+//                                offsetX = -maxSwipe
+//                            } else {
+//                                offsetX = 0f
+//                                onReset() // 스와이프가 닫히면 상태 초기화
+//                            }
+//                        }
+//                    }
+//                ) { change, dragAmount ->
+//                    change.consume()
+//                    offsetX = (offsetX + dragAmount).coerceIn(-maxSwipe, 0f)
+//                }
                 detectHorizontalDragGestures(
-                    onDragEnd = {
+                    onHorizontalDrag = { _, dragAmount ->
                         scope.launch {
-                            if (offsetX < -80f) {
-                                onSwipe() // 다른 버튼을 닫고 이 버튼만 스와이프
-                                offsetX = -maxSwipe
-                            } else {
-                                offsetX = 0f
-                                onReset() // 스와이프가 닫히면 상태 초기화
+                            val newOffset = (offset.value + dragAmount)
+                                .coerceIn(-maxSwipe, 0f)
+                            offset.snapTo(newOffset)
+                        }
+                    },
+                    onDragEnd = {
+                        if (offset.value < -maxSwipe / 2) {
+                            scope.launch {
+                                offset.animateTo(-maxSwipe)
                             }
+                            onSwipe()
+                        } else {
+                            scope.launch {
+                                offset.animateTo(0f)
+                            }
+                            onReset()
                         }
                     }
-                ) { change, dragAmount ->
-                    change.consume()
-                    offsetX = (offsetX + dragAmount).coerceIn(-maxSwipe, 0f)
-                }
+                )
             }
     ) {
         Box(
@@ -94,10 +129,12 @@ fun MenuFolderButton(
         // 스와이프 상태일 때만 offset 적용
         Box(
             modifier = Modifier
-                .offset(x = if (isSwiped) offsetX.dp else 0.dp)
-                .clickable(onClick = onButtonClick)
+//                .offset(x = if (isSwiped) offset.value.dp else 0.dp)
+                .offset { IntOffset(offset.value.roundToInt(), 0) }
+
         ) {
             MenuFolderContent(
+                onClick = onButtonClick,
                 menuFolder = menuFolder
             )
         }
@@ -161,6 +198,7 @@ fun MenuFolderDeleteButton(onDeleteClick: () -> Unit = {}) {
 
 @Composable
 fun MenuFolderContent(
+    onClick: () -> Unit = {},
     menuFolder: MenuFolderList,
 ) {
     val menuCount = menuFolder.menuIds.size
@@ -176,6 +214,7 @@ fun MenuFolderContent(
             modifier = Modifier
                 .fillMaxSize()
                 .clip(RoundedCornerShape(12.dp))
+                .clickable(onClick = onClick)
         )
 
         Box(

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/navigation/MenuFolderNavigation.kt
@@ -1,5 +1,7 @@
 package com.kuit.ourmenu.ui.menuFolder.navigation
 
+import android.R.attr.padding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -33,6 +35,7 @@ fun NavController.navigateToMenuInfo(menuId: Int) {
 }
 
 fun NavGraphBuilder.menuFolderNavGraph(
+    padding: PaddingValues,
     navigateBack: () -> Unit,
     navigateToMenuFolderDetail: (Int) -> Unit,
     navigateToMenuFolderAllMenu: () -> Unit,
@@ -41,6 +44,7 @@ fun NavGraphBuilder.menuFolderNavGraph(
 ) {
     composable<MainTabRoute.MenuFolder> {
         MenuFolderScreen(
+            padding = padding,
             onNavigateToDetail = navigateToMenuFolderDetail,
             onNavigateToAllMenu = navigateToMenuFolderAllMenu,
             onNavigateToAddMenu = navigateToAddMenu,

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
@@ -102,6 +102,9 @@ fun MenuFolderScreen(
                     onReset = { if (swipedIndex == index) swipedIndex = -1 },
                     onButtonClick = {
                         onNavigateToDetail(folder.menuFolderId)
+                    },
+                    onDeleteClick = {
+                        viewModel.deleteMenuFolder(folder.menuFolderId)
                     }
                 )
             }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
@@ -123,8 +123,9 @@ fun MenuFolderScreen(
                         onDragStart = { offset ->
                             swipedIndex = -1
                             dragAndDropListState.onDragStart(offset)
-                            dragStartFolderId =
-                                menuFolders[dragAndDropListState.initialIndex ?: 0].menuFolderId
+                            dragStartFolderId = dragAndDropListState.initialIndex?.let { index ->
+                                menuFolders.getOrNull(index)?.menuFolderId ?: -1
+                            } ?: -1
                         },
                         onDragEnd = {
                             viewModel.patchMenuFolders(

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/screen/MenuFolderScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -28,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kuit.ourmenu.R
 import com.kuit.ourmenu.ui.menuFolder.component.AddButton
+import com.kuit.ourmenu.ui.menuFolder.component.DeleteMenuFolderModal
 import com.kuit.ourmenu.ui.menuFolder.component.MenuFolderButton
 import com.kuit.ourmenu.ui.menuFolder.component.MenuFolderTopAppBar
 import com.kuit.ourmenu.ui.menuFolder.viewmodel.MenuFolderViewModel
@@ -47,6 +49,8 @@ fun MenuFolderScreen(
 
     val menuFolders by viewModel.menuFolders.collectAsStateWithLifecycle()
     val totalMenuCount by viewModel.menuCount.collectAsStateWithLifecycle()
+    var showDeleteModel by remember { mutableStateOf(false) }
+    var deleteIndex by remember { mutableIntStateOf(-1) }
 
     Log.d("MenuFolderScreen", "menuFolders: $menuFolders")
 
@@ -59,6 +63,20 @@ fun MenuFolderScreen(
             )
         }
     ) { innerPadding ->
+        if (showDeleteModel) {
+            DeleteMenuFolderModal(
+                onDismiss = {
+                    deleteIndex = -1
+                    showDeleteModel = false
+                },
+                onConfirm = {
+                    deleteIndex = -1
+                    viewModel.deleteMenuFolder(deleteIndex)
+                    swipedIndex = -1
+                }
+            )
+        }
+
         LazyColumn(
             modifier = Modifier
                 .padding(innerPadding)
@@ -104,7 +122,8 @@ fun MenuFolderScreen(
                         onNavigateToDetail(folder.menuFolderId)
                     },
                     onDeleteClick = {
-                        viewModel.deleteMenuFolder(folder.menuFolderId)
+                        showDeleteModel = true
+                        deleteIndex = folder.menuFolderId
                     }
                 )
             }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderViewModel.kt
@@ -86,8 +86,6 @@ class MenuFolderViewModel @Inject constructor(
 
         val toIndex = to.coerceAtMost(_menuFolders.value.size - 1)
 
-        val index = _menuFolders.value[toIndex].index
-
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderViewModel.kt
@@ -52,4 +52,23 @@ class MenuFolderViewModel @Inject constructor(
             _isLoading.value = false
         }
     }
+
+    fun deleteMenuFolder(menuFolderId: Int) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+
+            menuFolderRepository.deleteMenuFolder(menuFolderId.toLong())
+                .fold(
+                    onSuccess = {
+                        getMenuFolders() // Refresh the list after deletion
+                    },
+                    onFailure = { throwable ->
+                        _error.value = throwable.message ?: "메뉴 폴더 삭제 중 오류가 발생했습니다."
+                    }
+                )
+
+            _isLoading.value = false
+        }
+    }
 }

--- a/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/menuFolder/viewmodel/MenuFolderViewModel.kt
@@ -1,12 +1,16 @@
 package com.kuit.ourmenu.ui.menuFolder.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kuit.ourmenu.data.model.menuFolder.request.MenuFolderIndexRequest
 import com.kuit.ourmenu.data.model.menuFolder.response.MenuFolderList
 import com.kuit.ourmenu.data.repository.MenuFolderRepository
+import com.kuit.ourmenu.utils.dragndrop.move
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -65,6 +69,39 @@ class MenuFolderViewModel @Inject constructor(
                     },
                     onFailure = { throwable ->
                         _error.value = throwable.message ?: "메뉴 폴더 삭제 중 오류가 발생했습니다."
+                    }
+                )
+
+            _isLoading.value = false
+        }
+    }
+
+    fun updateMenuFolderList(from: Int, to: Int) {
+        val newMenuFolders = _menuFolders.value.toMutableList()
+        newMenuFolders.move(from, to)
+        _menuFolders.update { newMenuFolders }
+    }
+
+    fun patchMenuFolders(fromId: Int, to: Int) {
+
+        val toIndex = to.coerceAtMost(_menuFolders.value.size - 1)
+
+        val index = _menuFolders.value[toIndex].index
+
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+
+            menuFolderRepository.updateMenuFolderIndex(
+                fromId.toLong(),
+                MenuFolderIndexRequest(toIndex)
+            )
+                .fold(
+                    onSuccess = {
+                        getMenuFolders() // Refresh the list after patching
+                    },
+                    onFailure = { throwable ->
+                        _error.value = throwable.message ?: "메뉴 폴더 순서 변경 중 오류가 발생했습니다."
                     }
                 )
 

--- a/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/navigator/MainNavHost.kt
@@ -60,6 +60,7 @@ fun MainNavHost(
         )
 
         menuFolderNavGraph(
+            padding = padding,
             navigateBack = navController::navigateUp,
             navigateToMenuFolderDetail = navController::navigateToMenuFolderDetail,
             navigateToMenuFolderAllMenu = navController::navigateToMenuFolderAllMenu,

--- a/app/src/main/java/com/kuit/ourmenu/ui/onboarding/screen/LandingScreen.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/onboarding/screen/LandingScreen.kt
@@ -63,7 +63,7 @@ fun LandingRoute(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current as Activity
-//    LaunchedEffect(Unit) { navigateToHome() }
+    LaunchedEffect(Unit) { navigateToHome() }
 
     LaunchedEffect(uiState.kakaoState) {
         Log.d("KakaoModule", uiState.kakaoState.toString())

--- a/app/src/main/java/com/kuit/ourmenu/utils/dragndrop/DragAndDropListState.kt
+++ b/app/src/main/java/com/kuit/ourmenu/utils/dragndrop/DragAndDropListState.kt
@@ -1,0 +1,121 @@
+package com.kuit.ourmenu.utils.dragndrop
+
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+
+@Composable
+fun rememberDragAndDropListState(
+    lazyListState: LazyListState,
+    onMove: (Int, Int) -> Unit
+): DragAndDropListState {
+    return remember { DragAndDropListState(lazyListState, onMove) }
+}
+
+class DragAndDropListState(
+    val lazyListState: LazyListState,
+    private val onMove: (Int, Int) -> Unit
+) {
+    private var draggingDistance by mutableFloatStateOf(0f)
+    private var initialDraggingElement by mutableStateOf<LazyListItemInfo?>(null)
+
+    val initialIndex: Int?
+        get() = initialDraggingElement?.index?.takeIf { it > 0 }?.minus(1) ?: -1
+    val endIndex: Int?
+        get() = currentIndexOfDraggedItem?.takeIf { it >= 0 }
+    var currentIndexOfDraggedItem by mutableStateOf<Int?>(null)
+    private val initialOffsets: Pair<Int, Int>?
+        get() = initialDraggingElement?.let { Pair(it.offset, it.offsetEnd) }
+    val elementDisplacement: Float?
+        get() = currentIndexOfDraggedItem?.let {
+            lazyListState.getVisibleItemInfo(it + 1)
+        }?.let { itemInfo ->
+            (initialDraggingElement?.offset ?: 0f).toFloat() + draggingDistance - itemInfo.offset
+        }
+    private val currentElement: LazyListItemInfo?
+        get() = currentIndexOfDraggedItem?.let {
+            lazyListState.getVisibleItemInfo(it + 1)
+        }
+
+    fun onDragStart(offset: Offset) {
+        lazyListState.layoutInfo.visibleItemsInfo
+            .firstOrNull { item -> offset.y.toInt() in item.offset..item.offsetEnd }
+            ?.also {
+                if (it.index > 0) {
+                    initialDraggingElement = it
+                    currentIndexOfDraggedItem = it.index - 1
+                }
+            }
+    }
+
+    fun onDragInterrupted() {
+        initialDraggingElement = null
+        currentIndexOfDraggedItem = null
+        draggingDistance = 0f
+    }
+
+    fun onDrag(offset: Offset) {
+        draggingDistance += offset.y
+
+        initialOffsets?.let { (top, bottom) ->
+            val startOffset = top.toFloat() + draggingDistance
+            val endOffset = bottom.toFloat() + draggingDistance
+
+            currentElement?.let { current ->
+                lazyListState.layoutInfo.visibleItemsInfo
+                    .filterNot { item ->
+                        item.offsetEnd < startOffset || item.offset > endOffset || current.index == item.index
+                    }
+                    .firstOrNull { item ->
+                        val delta = startOffset - current.offset
+                        when {
+                            delta < 0 -> item.offset > startOffset
+                            else -> item.offsetEnd < endOffset
+                        }
+                    }
+            }?.also { item ->
+                currentIndexOfDraggedItem?.let { current ->
+                    if (item.index > 0) {
+                        onMove.invoke(current, item.index - 1)
+                    }
+                }
+                if (item.index > 0) {
+                    currentIndexOfDraggedItem = item.index - 1
+                }
+            }
+        }
+    }
+
+    fun checkOverscroll(): Float {
+        return initialDraggingElement?.let {
+            val startOffset = it.offset + draggingDistance
+            val endOffset = it.offsetEnd + draggingDistance
+
+            return@let when {
+                draggingDistance > 0 -> {
+                    (endOffset - lazyListState.layoutInfo.viewportEndOffset).takeIf { diff -> diff > 0 }
+
+                }
+
+                draggingDistance < 0 -> {
+                    (startOffset - lazyListState.layoutInfo.viewportStartOffset).takeIf { diff -> diff < 0 }
+                }
+
+                else -> null
+            }
+        } ?: 0f
+    }
+
+    private fun LazyListState.getVisibleItemInfo(itemPosition: Int): LazyListItemInfo? {
+        return this.layoutInfo.visibleItemsInfo.getOrNull(itemPosition - this.firstVisibleItemIndex)
+    }
+
+    private val LazyListItemInfo.offsetEnd: Int
+        get() = this.offset + this.size
+}

--- a/app/src/main/java/com/kuit/ourmenu/utils/dragndrop/Ext.kt
+++ b/app/src/main/java/com/kuit/ourmenu/utils/dragndrop/Ext.kt
@@ -1,0 +1,32 @@
+package com.kuit.ourmenu.utils.dragndrop
+
+import android.util.Log
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.zIndex
+
+fun <T> MutableList<T>.move(from: Int, to: Int) {
+    if (from == to) return
+    if (to > this.size - 1) return
+    Log.d("DragAndDrop", "Moving item from $from to $to , ${this.size}")
+    val element = this.removeAt(from)
+    try {
+        this.add(to, element)
+    } catch (e: IndexOutOfBoundsException) {
+        this.add(element)
+    }
+}
+
+fun Modifier.dragModifier(index: Int, dragAndDropListState: DragAndDropListState) = composed {
+    val isDragging = index == dragAndDropListState.currentIndexOfDraggedItem
+    val offsetOrNull = dragAndDropListState.elementDisplacement.takeIf { isDragging }
+
+    this
+        .zIndex(if (isDragging) 1f else 0f)
+        .graphicsLayer {
+            translationY = offsetOrNull ?: 0f
+            scaleX = if (isDragging) 1.03f else 1f
+            scaleY = if (isDragging) 1.03f else 1f
+        }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,9 @@
     <string name="taste">맛</string>
     <string name="occasion">상황</string>
 
+    <string name="delete_menu_folder_modal_title">정말로 삭제하시겠어요?</string>
+    <string name="delete_menu_folder_modal_content">삭제하면 복구가 어려울 수 있어요.\n다시 한 번 확인해 주세요.</string>
+
     <!--my page-->
     <string name="now_meal_time">현재 설정하신 식사 시간입니다!</string>
     <string name="change_meal_time">식사 시간 수정하기</string>


### PR DESCRIPTION
## 🚀 이슈번호
- closed #74 
## ✏️ 변경사항
- 메뉴판 삭제
- 메뉴판 순서 변경


## 📷 스크린샷
<img src="" width="360"/>

https://github.com/user-attachments/assets/b1429564-0c0c-443a-affb-0e94ac85ac0d



## ✍️ 사용법



## 🎸 기타
코드가 많이 개판... 추후 리팩토링할 때 하겠습니다.
코드를 확실히 이해하고 진행했어야 하는데 빠르게 개발하기 위해서 ... 

참고) https://dev.to/mardsoul/how-to-create-lazycolumn-with-drag-and-drop-elements-in-jetpack-compose-part-1-4bn5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 메뉴 폴더의 드래그 앤 드롭(순서 변경) 기능 추가
  * 메뉴 폴더 삭제 확인 모달 추가
  * 삭제 및 순서 변경 API 연동 도입

* **버그 수정**
  * 온보딩 화면에서 홈으로 자동 이동이 정상 동작하도록 수정

* **UI/UX 개선**
  * 메뉴 폴더 버튼의 스와이프·클릭 반응 개선
  * 드래그 앤 드롭 시 시각적 효과와 부드러운 애니메이션 적용

* **문서 및 리소스**
  * 삭제 확인 모달 안내 문구 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->