### PR TITLE
[FIX] AddMenu에서 선택된 메뉴에 해당하는 data class 추가

### DIFF
--- a/app/src/main/java/com/kuit/ourmenu/ui/addmenu/viewmodel/AddMenuViewModel.kt
+++ b/app/src/main/java/com/kuit/ourmenu/ui/addmenu/viewmodel/AddMenuViewModel.kt
@@ -57,6 +57,16 @@ class AddMenuViewModel @Inject constructor(
     private val _locationPermissionGranted = MutableStateFlow(false)
     val locationPermissionGranted: StateFlow<Boolean> = _locationPermissionGranted.asStateFlow()
 
+    private val _selectedMenuData = MutableStateFlow<SelectedMenuData>(
+        SelectedMenuData(
+            menuName = "",
+            price = "",
+            storeName = "",
+            address = ""
+        )
+    )
+    val selectedMenuData: StateFlow<SelectedMenuData> = _selectedMenuData.asStateFlow()
+
     init {
         viewModelScope.launch {
             preferencesManager.locationPermissionGranted.collect { granted ->
@@ -250,10 +260,9 @@ class AddMenuViewModel @Inject constructor(
     }
 }
 
-// TODO: 이후에 dto 반영시 삭제 예정
-data class AddMenuDummyStoreInfo(
-    val imgList: List<Int> = emptyList(),
-    val name: String = "",
+data class SelectedMenuData(
+    val menuName: String = "",
+    val price: String = "",
+    val storeName: String = "",
     val address: String = "",
-    val menuList: List<Boolean> = emptyList(),
 )


### PR DESCRIPTION
## 🚀 이슈번호

## ✏️ 변경사항
- AddMenuViewModel에 SelectedMenuData() 추가


## 📷 스크린샷

## ✍️ 사용법


## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 추가 흐름에서 선택한 메뉴 정보(메뉴명, 가격, 매장명, 주소)를 일관되게 표시·유지합니다.
- 리팩터링
  - 더미 데이터 의존을 제거하고 상태 기반 관리로 전환해 입력 변경이 안정적으로 반영되고 화면 이동 시 값이 유지되며 전반적 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->