### PR TITLE
[FIX] 토큰 재발급 및 실패시 로직 수정

### DIFF
--- a/app/src/main/java/com/kuit/ourmenu/MainActivity.kt
+++ b/app/src/main/java/com/kuit/ourmenu/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.kuit.ourmenu
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -12,23 +13,42 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
+import coil3.imageLoader
 import com.kuit.ourmenu.ui.navigator.MainNavHost
 import com.kuit.ourmenu.ui.navigator.MainTab
 import com.kuit.ourmenu.ui.navigator.component.MainBottomBar
 import com.kuit.ourmenu.ui.navigator.rememberMainNavigator
-import androidx.navigation.compose.rememberNavController
-import coil3.imageLoader
 import com.kuit.ourmenu.ui.onboarding.screen.SplashScreen
 import com.kuit.ourmenu.ui.theme.NeutralWhite
 import com.kuit.ourmenu.ui.theme.OurMenuTheme
+import com.kuit.ourmenu.utils.auth.TokenManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject
+    lateinit var tokenManager: TokenManager
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // 로그아웃 이벤트 구독
+        lifecycleScope.launch {
+            tokenManager.logoutEvent.collect {
+                // Activity 스택을 모두 클리어하고 MainActivity를 다시 시작
+                val intent = Intent(this@MainActivity, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+                startActivity(intent)
+                finish()
+            }
+        }
+
         setContent {
             var showSplash by remember { mutableStateOf(true) }
             val navController = rememberMainNavigator()

--- a/app/src/main/java/com/kuit/ourmenu/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/repository/AuthRepository.kt
@@ -72,11 +72,6 @@ class AuthRepository @Inject constructor(
     }
 
 
-    suspend fun reissueToken(
-        refreshToken: String
-    ) = runCatching {
-        authService.reissueToken(refreshToken).handleBaseResponse().getOrThrow()
-    }
 
     suspend fun sendEmail(
         email: String

--- a/app/src/main/java/com/kuit/ourmenu/data/service/AuthService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/AuthService.kt
@@ -7,7 +7,6 @@ import com.kuit.ourmenu.data.model.auth.request.SignupRequest
 import com.kuit.ourmenu.data.model.auth.response.CheckKakaoEmailResponse
 import com.kuit.ourmenu.data.model.auth.response.EmailResponse
 import com.kuit.ourmenu.data.model.auth.response.LoginResponse
-import com.kuit.ourmenu.data.model.auth.response.ReissueTokenResponse
 import com.kuit.ourmenu.data.model.auth.response.SignupResponse
 import com.kuit.ourmenu.data.model.base.BaseResponse
 import retrofit2.http.Body
@@ -27,10 +26,6 @@ interface AuthService {
         @Body request: LoginRequest
     ): BaseResponse<LoginResponse>
 
-    @POST("api/users/reissue-token")
-    suspend fun reissueToken(
-        @Body refreshToken: String
-    ): BaseResponse<ReissueTokenResponse>
 
     @POST("/api/users/auth/kakao")
     suspend fun checkKakaoEmail(

--- a/app/src/main/java/com/kuit/ourmenu/data/service/TokenService.kt
+++ b/app/src/main/java/com/kuit/ourmenu/data/service/TokenService.kt
@@ -1,0 +1,13 @@
+package com.kuit.ourmenu.data.service
+
+import com.kuit.ourmenu.data.model.auth.response.ReissueTokenResponse
+import com.kuit.ourmenu.data.model.base.BaseResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface TokenService {
+    @POST("api/users/reissue-token")
+    suspend fun reissueToken(
+        @Body refreshToken: String
+    ): BaseResponse<ReissueTokenResponse>
+}

--- a/app/src/main/java/com/kuit/ourmenu/utils/auth/TokenAuthenticator.kt
+++ b/app/src/main/java/com/kuit/ourmenu/utils/auth/TokenAuthenticator.kt
@@ -1,9 +1,9 @@
 package com.kuit.ourmenu.utils.auth
 
+import android.util.Log
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.kuit.ourmenu.BuildConfig
-import com.kuit.ourmenu.data.model.auth.response.ReissueTokenResponse
-import com.kuit.ourmenu.data.service.AuthService
+import com.kuit.ourmenu.data.service.TokenService
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -13,7 +13,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import javax.inject.Inject
 
@@ -21,42 +20,46 @@ class TokenAuthenticator @Inject constructor(
     private val tokenManager: TokenManager,
 ): Authenticator {
     override fun authenticate(route: Route?, response: Response): Request? {
-        val refreshToken = runBlocking {
-            tokenManager.getRefreshToken().first()
+        // 이미 재시도했던 요청인 경우 null을 반환하여 재시도 중단
+        if (response.request.header("Retry-With-New-Token") != null) {
+            return null
         }
+
         return runBlocking {
-            if (refreshToken.isNullOrEmpty()){
-                return@runBlocking null
-            }
-            val newToken = getNewToken(refreshToken)
+            try {
+                val refreshToken = tokenManager.getRefreshToken().first()
+                if (refreshToken == null) {
+                    tokenManager.clearToken()
+                    return@runBlocking null
+                }
 
-            if (newToken == null) {
-                tokenManager.clearToken()
-            }
-
-            newToken?.let {
-                tokenManager.saveAccessToken(it.accessToken)
-                response.request.newBuilder()
-                    .header("Authorization", "Bearer ${it.accessToken}")
+                // 토큰 재발급 요청
+                val tokenService = Retrofit.Builder()
+                    .baseUrl(BuildConfig.BASE_URL)
+                    .client(OkHttpClient.Builder().build())
+                    .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
                     .build()
+                    .create(TokenService::class.java)
+                val tokenResponse = tokenService.reissueToken(
+                    refreshToken = refreshToken
+                )
+
+                // 새로운 토큰 저장
+                tokenManager.saveAccessToken(tokenResponse.response?.accessToken ?: "")
+                tokenManager.saveRefreshToken(tokenResponse.response?.refreshToken ?: "")
+                Log.d("TokenAuthenticator", "토큰 재발급 성공: ${tokenResponse.response?.accessToken}")
+
+                // 기존 요청에 새로운 토큰으로 헤더를 추가하여 재시도
+                response.request.newBuilder()
+                    .header("Authorization", "Bearer ${tokenResponse.response?.accessToken}")
+                    .header("Retry-With-New-Token", "true")
+                    .build()
+            } catch (e: Exception) {
+                // 토큰 재발급 실패 시 토큰 클리어
+                Log.d("TokenAuthenticator", "토큰 재발급 실패: ${e.message}")
+                tokenManager.clearToken()
+                null
             }
         }
     }
-
-    private suspend fun getNewToken(refreshToken: String): ReissueTokenResponse? {
-        val loggingInterceptor = HttpLoggingInterceptor()
-        loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
-        val okHttpClient = OkHttpClient.Builder().addInterceptor(loggingInterceptor).build()
-
-        val retrofit = Retrofit.Builder()
-            .baseUrl(BuildConfig.BASE_URL)
-            .addConverterFactory(
-                Json.asConverterFactory(requireNotNull("application/json".toMediaType()))
-            )
-            .client(okHttpClient)
-            .build()
-        val service = retrofit.create(AuthService::class.java)
-        return service.reissueToken(refreshToken).response
-    }
-
 }

--- a/app/src/main/java/com/kuit/ourmenu/utils/auth/TokenManager.kt
+++ b/app/src/main/java/com/kuit/ourmenu/utils/auth/TokenManager.kt
@@ -6,6 +6,8 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,6 +16,9 @@ private val Context.dataStore by preferencesDataStore(name = "user_prefs")
 
 @Singleton
 class TokenManager @Inject constructor(@ApplicationContext private val context: Context) {
+    private val _logoutEvent = MutableSharedFlow<Unit>()
+    val logoutEvent = _logoutEvent.asSharedFlow()
+
     companion object {
         private val ACCESS_TOKEN = stringPreferencesKey("access_token")
         private val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
@@ -48,5 +53,6 @@ class TokenManager @Inject constructor(@ApplicationContext private val context: 
             preferences.remove(ACCESS_TOKEN)
             preferences.remove(REFRESH_TOKEN)
         }
+        _logoutEvent.emit(Unit)
     }
 }


### PR DESCRIPTION
## 🚀 이슈번호
- resolves #46 
## ✏️ 변경사항
- 토큰 재발급 요청시 사용할 Service를 분리하여 무한루프 방지
- 기존 토큰 재발급 로직 수정
- 토큰 재발급 실패시 로그아웃 및 Activity 재시작 구현


## 📷 스크린샷


## ✍️ 사용법



## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 세션 만료 또는 로그아웃 발생 시 앱이 즉시 초기 화면으로 안전하게 복귀하도록 처리하여 사용자 경험 개선.
- 버그 수정
  - 토큰 재발급 실패 시 무한 재시도되는 문제를 방지하고, 예외 처리 강화를 통해 비정상 로그인 상태 지속을 차단.
- 리팩터링
  - 인증 토큰 재발급 흐름을 정비하여 안정성과 신뢰도를 높임.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->